### PR TITLE
Adding Construction Wand data

### DIFF
--- a/src/main/resources/data/constructionwand/pmmo/items/core_angel.json
+++ b/src/main/resources/data/constructionwand/pmmo/items/core_angel.json
@@ -1,0 +1,25 @@
+{
+    "override": true,
+    "xp_values":{
+        "CRAFT": {
+            "crafting": 2000,
+            "smithing": 300
+        }
+    },
+    "salvage":{
+        "minecraft:gold_ingot": {
+            "salvageMax": 2,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.005
+            },
+            "levelReq": {
+                "smithing": 5
+            },
+            "xpPerItem": {
+                "smithing": 30
+            }
+        }
+    }
+}

--- a/src/main/resources/data/constructionwand/pmmo/items/core_destruction.json
+++ b/src/main/resources/data/constructionwand/pmmo/items/core_destruction.json
@@ -1,0 +1,39 @@
+{
+    "override": true,
+    "xp_values":{
+        "CRAFT": {
+            "crafting": 10000,
+            "smithing": 7000
+        }
+    },
+    "salvage":{
+        "minecraft:diamond": {
+            "salvageMax": 6,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.005
+            },
+            "levelReq": {
+                "smithing": 5
+            },
+            "xpPerItem": {
+                "smithing": 30
+            }
+        },
+        "minecraft:diamond_block": {
+            "salvageMax": 1,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.005
+            },
+            "levelReq": {
+                "smithing": 5
+            },
+            "xpPerItem": {
+                "smithing": 180
+            }
+        }
+    }
+}

--- a/src/main/resources/data/constructionwand/pmmo/items/diamond_wand.json
+++ b/src/main/resources/data/constructionwand/pmmo/items/diamond_wand.json
@@ -1,0 +1,59 @@
+{
+    "override": true,
+    "xp_values":{
+        "ANVIL_REPAIR" :{
+            "smithing": 4000
+        },
+        "CRAFT": {
+            "crafting": 4000,
+            "smithing": 700
+        },
+        "ACTIVATE_ITEM":{
+            "building": 500
+        },
+        "ENCHANT": {
+            "magic": 120
+        }
+    },
+    "requirements":{
+        "INTERACT":{
+            "building": 60
+        },
+        "USE":{
+            "building": 60
+        }
+    },
+    "bonuses":{
+        "HELD":{
+            "building": 1.5
+        }
+    },
+    "salvage":{
+        "minecraft:diamond": {
+            "salvageMax": 1,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.005
+            },
+            "levelReq": {
+                "smithing": 5
+            },
+            "xpPerItem": {
+                "smithing": 30
+            }
+        },
+        "minecraft:stick": {
+            "salvageMax": 2,
+            "baseChance": 0.15,
+            "maxChance": 1,
+            "chancePerLevel": {
+                "smithing": 0.05
+            },
+            "levelReq": {},
+            "xpPerItem": {
+                "smithing": 10
+            }
+        }
+    }
+}

--- a/src/main/resources/data/constructionwand/pmmo/items/infinity_wand.json
+++ b/src/main/resources/data/constructionwand/pmmo/items/infinity_wand.json
@@ -1,0 +1,59 @@
+{
+    "override": true,
+    "xp_values":{
+        "ANVIL_REPAIR" :{
+            "smithing": 7000
+        },
+        "CRAFT": {
+            "crafting": 7000,
+            "smithing": 1000
+        },
+        "ACTIVATE_ITEM":{
+            "building": 1000
+        },
+        "ENCHANT": {
+            "magic": 180
+        }
+    },
+    "requirements":{
+        "INTERACT":{
+            "building": 90
+        },
+        "USE":{
+            "building": 90
+        }
+    },
+    "bonuses":{
+        "HELD":{
+            "building": 2.0
+        }
+    },
+    "salvage":{
+        "minecraft:nether_star": {
+            "salvageMax": 1,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.002
+            },
+            "levelReq": {
+                "smithing": 10
+            },
+            "xpPerItem": {
+                "smithing": 30
+            }
+        },
+        "minecraft:stick": {
+            "salvageMax": 2,
+            "baseChance": 0.15,
+            "maxChance": 1,
+            "chancePerLevel": {
+                "smithing": 0.05
+            },
+            "levelReq": {},
+            "xpPerItem": {
+                "smithing": 10
+            }
+        }
+    }
+}

--- a/src/main/resources/data/constructionwand/pmmo/items/iron_wand.json
+++ b/src/main/resources/data/constructionwand/pmmo/items/iron_wand.json
@@ -1,0 +1,59 @@
+{
+    "override": true,
+    "xp_values":{
+        "ANVIL_REPAIR" :{
+            "smithing": 1500
+        },
+        "CRAFT": {
+            "crafting": 2000,
+            "smithing": 300
+        },
+        "ACTIVATE_ITEM":{
+            "building": 200
+        },
+        "ENCHANT": {
+            "magic": 60
+        }
+    },
+    "requirements":{
+        "INTERACT":{
+            "building": 30
+        },
+        "USE":{
+            "building": 30
+        }
+    },
+    "bonuses":{
+        "HELD":{
+            "building": 1.10
+        }
+    },
+    "salvage":{
+        "minecraft:iron_ingot": {
+            "salvageMax": 1,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.005
+            },
+            "levelReq": {
+                "smithing": 5
+            },
+            "xpPerItem": {
+                "smithing": 30
+            }
+        },
+        "minecraft:stick": {
+            "salvageMax": 2,
+            "baseChance": 0.15,
+            "maxChance": 1,
+            "chancePerLevel": {
+                "smithing": 0.05
+            },
+            "levelReq": {},
+            "xpPerItem": {
+                "smithing": 10
+            }
+        }
+    }
+}

--- a/src/main/resources/data/constructionwand/pmmo/items/stone_wand.json
+++ b/src/main/resources/data/constructionwand/pmmo/items/stone_wand.json
@@ -1,0 +1,59 @@
+{
+    "override": true,
+    "xp_values":{
+        "ANVIL_REPAIR" :{
+            "smithing": 1000
+        },
+        "CRAFT": {
+            "crafting": 1500,
+            "smithing": 200
+        },
+        "ACTIVATE_ITEM":{
+            "building": 100
+        },
+        "ENCHANT": {
+            "magic": 30
+        }
+    },
+    "requirements":{
+        "INTERACT":{
+            "building": 10
+        },
+        "USE":{
+            "building": 10
+        }
+    },
+    "bonuses":{
+        "HELD":{
+            "building": 1.05
+        }
+    },
+    "salvage":{
+        "minecraft:cobblestone": {
+            "salvageMax": 1,
+            "baseChance": 0.0,
+            "maxChance": 0.9,
+            "chancePerLevel": {
+                "smithing": 0.005
+            },
+            "levelReq": {
+                "smithing": 5
+            },
+            "xpPerItem": {
+                "smithing": 30
+            }
+        },
+        "minecraft:stick": {
+            "salvageMax": 2,
+            "baseChance": 0.15,
+            "maxChance": 1,
+            "chancePerLevel": {
+                "smithing": 0.05
+            },
+            "levelReq": {},
+            "xpPerItem": {
+                "smithing": 10
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is for the [Construction Wand](https://github.com/Theta-Dev/ConstructionWand) mod.

I pulled the craft values for the wands from shovels of appropriate types, as I did the same with the salvage.

For the infinity wand (uses nether star), I used diamond values but a little higher (harder to salvage, more xp for crafting).

For the two cores, I just picked the most expensive resource in each to give salvage for (diamond block for demon, 2 gold bars for angel), and gave them appropriate salvage rates. Crafting value on them was compared to pickaxes of the appropriate material types (but scaled up massively on demon core since it uses a block of diamond and two diamond picks).