### PR TITLE
#229 Update Smelting/Cooking to use Result not Input config values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.5-3.68.2'
+version = '1.16.5-3.69.0'
 group = 'harmonised.pmmo'
 archivesBaseName = 'Project_MMO'
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.5-3.69.0'
+version = '1.16.5-3.68.2'
 group = 'harmonised.pmmo'
 archivesBaseName = 'Project_MMO'
 

--- a/src/main/java/harmonised/pmmo/config/AutoValues.java
+++ b/src/main/java/harmonised/pmmo/config/AutoValues.java
@@ -4,21 +4,22 @@ import com.google.common.collect.Multimap;
 import harmonised.pmmo.pmmo_saved_data.PmmoSavedData;
 import harmonised.pmmo.skills.Skill;
 import harmonised.pmmo.util.XP;
-import net.minecraft.block.*;
-import net.minecraft.block.material.Material;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.CropsBlock;
+import net.minecraft.block.OreBlock;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Food;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
+import net.minecraft.item.crafting.AbstractCookingRecipe;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
-import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.ToolType;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,7 +54,6 @@ public class AutoValues
                     JsonConfig.localData.get(jType).get(resLoc).put(entry.getKey(), value);
                 if(outputToConsole)
                 {
-                    //addData("xp_value_smelt", 	"#forge:ores/aluminum",	{ "smithing": 12.5 });
                     StringBuilder addDataString = new StringBuilder("addData(\"" + jType.toString().toLowerCase() + "\",\t\"" + resLoc + "\", { ");
                     boolean firstEntry = true;
                     for(Map.Entry<String, Double> jsonEntry : values.entrySet())
@@ -224,20 +224,7 @@ public class AutoValues
                 {
                     Item outputItem = recipe.getRecipeOutput().getItem();
                     itemsWithCookRecipe.add(outputItem);
-                    for(Ingredient ingredient : recipe.getIngredients())
-                    {
-                        for(ItemStack itemStack : ingredient.getMatchingStacks())
-                        {
-                            if(!cooksFrom.containsKey(outputItem))
-                                cooksFrom.put(outputItem, new HashSet<>());
-                            cooksFrom.get(outputItem).add(itemStack.getItem());
-                        }
-                    }
                 }
-//                else if(recipe.getType() == IRecipeType.BLASTING)
-//                {
-//                    itemsWithBlastRecipe.add(item);
-//                }
             }
 
             for(Item item : ForgeRegistries.ITEMS)
@@ -338,17 +325,14 @@ public class AutoValues
                                 {
                                     Map<String, Double> xpValueMap = new HashMap<>();
                                     xpValueMap.put(Skill.COOKING.toString(), cookingXp);
-                                    for(Item rawItem : cooksFrom.get(item))
+                                    String rawResLoc = item.getRegistryName().toString();
+                                    if(Config.forgeConfig.autoGenerateCookingXpEnabled.get())
+                                        addJsonConfigValue(rawResLoc, JType.XP_VALUE_COOK, xpValueMap, true);
+                                    if(Config.forgeConfig.autoGenerateCookingExtraChanceEnabled.get())
                                     {
-                                        String rawResLoc = rawItem.getRegistryName().toString();
-                                        if(Config.forgeConfig.autoGenerateCookingXpEnabled.get())
-                                            addJsonConfigValue(rawResLoc, JType.XP_VALUE_COOK, xpValueMap, true);
-                                        if(Config.forgeConfig.autoGenerateCookingExtraChanceEnabled.get())
-                                        {
-                                            Map<String, Double> extraChanceMap = new HashMap<>();
-                                            extraChanceMap.put("extraChance", 10D/(saturation*15+healing));
-                                            addJsonConfigValue(rawResLoc, JType.INFO_COOK, extraChanceMap, true);
-                                        }
+                                        Map<String, Double> extraChanceMap = new HashMap<>();
+                                        extraChanceMap.put("extraChance", 10D/(saturation*15+healing));
+                                        addJsonConfigValue(rawResLoc, JType.INFO_COOK, extraChanceMap, true);
                                     }
                                 }
                             }
@@ -366,7 +350,6 @@ public class AutoValues
                 {
                     try
                     {
-//                ItemStack itemStack = new ItemStack(block);
                         String resLoc = block.getRegistryName().toString();
                         JType jType = JType.NONE;
                         Map<String, Double> infoMap = new HashMap<>();

--- a/src/main/java/harmonised/pmmo/events/FurnaceHandler.java
+++ b/src/main/java/harmonised/pmmo/events/FurnaceHandler.java
@@ -17,7 +17,7 @@ public class FurnaceHandler
 {
     public static final Logger LOGGER = LogManager.getLogger();
 
-    public static void handleSmelted(ItemStack input, ItemStack output, World world, BlockPos pos, int type)
+    public static void handleSmelted(ItemStack output, World world, BlockPos pos, int type)
     {
         try
         {
@@ -43,13 +43,13 @@ public class FurnaceHandler
                     return;
             }
 
-            source += " " + input.getItem().getRegistryName();
-            source += " [" + XP.getDimResLoc(world).toString() + "|x" + pos.getX() + "|y" + pos.getY() + "|z" + pos.getZ() + "]";
+            source += " " + output.getItem().getRegistryName();
+            source += " [" + XP.getDimResLoc(world) + "|x" + pos.getX() + "|y" + pos.getY() + "|z" + pos.getZ() + "]";
             UUID uuid = ChunkDataHandler.checkPos(world, pos);
 
             if(uuid != null)
             {
-                double extraChance = XP.getExtraChance(uuid, input.getItem().getRegistryName(), infoType, false) / 100D;
+                double extraChance = XP.getExtraChance(uuid, output.getItem().getRegistryName(), infoType, false) / 100D;
 
                 int guaranteedDrop = (int) extraChance;
                 int extraDrop;
@@ -63,7 +63,7 @@ public class FurnaceHandler
 
                 output.grow(totalExtraDrops);
 
-                Map<String, Double> award = XP.multiplyMapAnyDouble(XP.getXp(input, xpType), 1 + totalExtraDrops);
+                Map<String, Double> award = XP.multiplyMapAnyDouble(XP.getXp(output, xpType), 1 + totalExtraDrops);
 
 
                 for(String awardSkillName : award.keySet())

--- a/src/main/java/harmonised/pmmo/mixin/AbstractFurnaceTileEntityShrinkMixin.java
+++ b/src/main/java/harmonised/pmmo/mixin/AbstractFurnaceTileEntityShrinkMixin.java
@@ -4,9 +4,6 @@ import harmonised.pmmo.events.FurnaceHandler;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.tileentity.AbstractFurnaceTileEntity;
-import net.minecraft.tileentity.BrewingStandTileEntity;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -27,7 +24,7 @@ public class AbstractFurnaceTileEntityShrinkMixin
     {
         World world = ((AbstractFurnaceTileEntity)(Object)this).getWorld();
         BlockPos pos = ((AbstractFurnaceTileEntity)(Object)this).getPos();
-        FurnaceHandler.handleSmelted(items.get(0), items.get(2), world, pos, 0);
-        FurnaceHandler.handleSmelted(items.get(0), items.get(2), world, pos, 1);
+        FurnaceHandler.handleSmelted(items.get(2), world, pos, 0);
+        FurnaceHandler.handleSmelted(items.get(2), world, pos, 1);
     }
 }

--- a/src/main/java/harmonised/pmmo/mixin/CampfireTileEntitySetMixin.java
+++ b/src/main/java/harmonised/pmmo/mixin/CampfireTileEntitySetMixin.java
@@ -4,8 +4,6 @@ import harmonised.pmmo.events.FurnaceHandler;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.CampfireTileEntity;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,6 +20,6 @@ public class CampfireTileEntitySetMixin
     {
         World world = ((CampfireTileEntity)(Object)this).getWorld();
         BlockPos pos = ((CampfireTileEntity)(Object)this).getPos();
-        FurnaceHandler.handleSmelted(itemstack, itemstack1, world, pos, 1);
+        FurnaceHandler.handleSmelted(itemstack1, world, pos, 1);
     }
 }

--- a/src/main/resources/assets/pmmo/util/xp_value_cook.json
+++ b/src/main/resources/assets/pmmo/util/xp_value_cook.json
@@ -1,32 +1,19 @@
 {
-	"foodexpansion:bat_wing":
+	"foodexpansion:cooked_bat_wing":
 	{
 		"cooking": 7.5
 	},
-	"minecraft:cactus":
+	"#forge:dyes":
 	{
 		"cooking": 12.5,
 		"crafting": 4
 	},
-	"minecraft:chorus_fruit":
+	"minecraft:popped_chorus_fruit":
 	{
 		"cooking": 25,
 		"crafting": 22.5
 	},
-	"minecraft:egg":
-	{
-		"cooking": 7.5
-	},
-	"minecraft:pumpkin_seed":
-	{
-		"cooking": 5
-	},
-	"minecraft:sea_pickle":
-	{
-		"cooking": 12.5,
-		"crafting": 3
-	},
-	"minecraft:wet_sponge":
+	"minecraft:sponge":
 	{
 		"cooking": 15,
 		"crafting": 15

--- a/src/main/resources/assets/pmmo/util/xp_value_smelt.json
+++ b/src/main/resources/assets/pmmo/util/xp_value_smelt.json
@@ -9,8 +9,12 @@
 		"smithing": 15
 	},
 	"#forge:dusts/saltpeter": {
-		"smithing": 14,
-		"magic": 2
+		"magic": 2,
+		"smithing": 14
+	},
+	"#forge:dusts/soulium": {
+		"magic": 4,
+		"smithing": 12
 	},
 	"#forge:gems/agate": {
 		"smithing": 18
@@ -19,8 +23,8 @@
 		"smithing": 18
 	},
 	"#forge:gems/amber": {
-		"smithing": 12,
-		"magic": 2
+		"magic": 2,
+		"smithing": 12
 	},
 	"#forge:gems/amethyst": {
 		"smithing": 18
@@ -38,8 +42,8 @@
 		"smithing": 18
 	},
 	"#forge:gems/aquamarine": {
-		"smithing": 15,
-		"magic": 2
+		"magic": 2,
+		"smithing": 15
 	},
 	"#forge:gems/benitoite": {
 		"smithing": 18
@@ -117,11 +121,15 @@
 		"smithing": 18
 	},
 	"#forge:gems/moonstone": {
-		"smithing": 12,
-		"magic": 2
+		"magic": 2,
+		"smithing": 12
 	},
 	"#forge:gems/morganite": {
 		"smithing": 18
+	},
+	"#forge:gems/negatite": {
+		"magic": 20,
+		"smithing": 10
 	},
 	"#forge:gems/onyx": {
 		"smithing": 18
@@ -137,6 +145,10 @@
 	},
 	"#forge:gems/phosphophyllite": {
 		"smithing": 18
+	},
+	"#forge:gems/positite": {
+		"magic": 20,
+		"smithing": 10
 	},
 	"#forge:gems/pyrope": {
 		"smithing": 18
@@ -186,9 +198,6 @@
 	"#forge:gravel": {
 		"smithing": 1
 	},
-	"#forge:ingots/brass": {
-		"smithing": 22
-	},
 	"#forge:ingots/aluminum": {
 		"smithing": 12.5
 	},
@@ -196,8 +205,12 @@
 		"smithing": 18
 	},
 	"#forge:ingots/arcane_gold": {
-		"smithing": 12,
-		"magic": 6
+		"magic": 6,
+		"smithing": 12
+	},
+	"#forge:ingots/awakened_supremium": {
+		"magic": 4,
+		"smithing": 18
 	},
 	"#forge:ingots/azure_electrum": {
 		"smithing": 22
@@ -220,9 +233,12 @@
 	"#forge:ingots/blaze_gold": {
 		"smithing": 18
 	},
+	"#forge:ingots/brass": {
+		"smithing": 22
+	},
 	"#forge:ingots/brick": {
-		"smithing": 1.5,
-		"crafting": 3.5
+		"crafting": 3.5,
+		"smithing": 1.5
 	},
 	"#forge:ingots/cloggrum": {
 		"smithing": 12
@@ -239,6 +255,9 @@
 	"#forge:ingots/cyanite": {
 		"smithing": 18
 	},
+	"#forge:ingots/endorium": {
+		"smithing": 20
+	},
 	"#forge:ingots/froststeel": {
 		"smithing": 12
 	},
@@ -249,8 +268,16 @@
 		"smithing": 12
 	},
 	"#forge:ingots/hellforged": {
-		"smithing": 18,
-		"magic": 4
+		"magic": 4,
+		"smithing": 18
+	},
+	"#forge:ingots/imperium": {
+		"magic": 2,
+		"smithing": 12
+	},
+	"#forge:ingots/inferium": {
+		"magic": 2,
+		"smithing": 12
 	},
 	"#forge:ingots/iron": {
 		"smithing": 12
@@ -277,11 +304,23 @@
 		"smithing": 12
 	},
 	"#forge:ingots/pewter": {
-		"smithing": 12,
-		"magic": 2
+		"magic": 2,
+		"smithing": 12
 	},
 	"#forge:ingots/platinum": {
 		"smithing": 28
+	},
+	"#forge:ingots/prosperity": {
+		"magic": 2,
+		"smithing": 12
+	},
+	"#forge:ingots/prudentium": {
+		"magic": 2,
+		"smithing": 12
+	},
+	"#forge:ingots/rainbow": {
+		"magic": 4,
+		"smithing": 18
 	},
 	"#forge:ingots/redstone_alloy": {
 		"smithing": 18
@@ -298,11 +337,26 @@
 	"#forge:ingots/silver": {
 		"smithing": 11
 	},
+	"#forge:ingots/soulium": {
+		"magic": 4,
+		"smithing": 12
+	},
 	"#forge:ingots/steel": {
 		"smithing": 16
 	},
+	"#forge:ingots/supremium": {
+		"magic": 2,
+		"smithing": 12
+	},
+	"#forge:ingots/tertium": {
+		"magic": 2,
+		"smithing": 12
+	},
 	"#forge:ingots/tin": {
 		"smithing": 6.5
+	},
+	"#forge:ingots/tungsten": {
+		"smithing": 20
 	},
 	"#forge:ingots/tyrian_steel": {
 		"smithing": 28
@@ -318,6 +372,10 @@
 	},
 	"#forge:ingots/zinc": {
 		"smithing": 16
+	},
+	"#forge:ingots/zitrite": {
+		"magic": 4,
+		"smithing": 12
 	},
 	"#forge:nuggets/gold": {
 		"smithing": 1.95
@@ -337,21 +395,6 @@
 	"#forge:stone": {
 		"smithing": 1
 	},
-	"#forge:storage_blocks/inferium_essence": {
-		"smithing": 12,
-		"magic": 2
-	},
-	"#forge:storage_blocks/prosperity_shard": {
-		"smithing": 12,
-		"magic": 2
-	},
-	"#forge:storage_blocks/soulium_dust": {
-		"smithing": 12,
-		"magic": 2
-	},
-	"#forge:storage_blocks/uraninite": {
-		"smithing": 18
-	},
 	"#forge:terracottas": {
 		"smithing": 1.5
 	},
@@ -362,8 +405,8 @@
 		"smithing": 1
 	},
 	"eidolon:enchanted_ash": {
-		"smithing": 1,
-		"magic": 2
+		"magic": 2,
+		"smithing": 1
 	},
 	"minecraft:cracked_nether_bricks": {
 		"smithing": 1.5
@@ -378,7 +421,10 @@
 		"smithing": 1
 	},
 	"minecraft:terracotta": {
-		"smithing": 6,
-		"crafting": 14
+		"crafting": 14,
+		"smithing": 6
+	},
+	"powah:uraninite": {
+		"smithing": 14
 	}
 }

--- a/src/main/resources/assets/pmmo/util/xp_value_smelt.json
+++ b/src/main/resources/assets/pmmo/util/xp_value_smelt.json
@@ -1,1444 +1,384 @@
 {
-	"#forge:ores/aluminum":
-	{
-		"smithing": 12.5
-	},
-	"#forge:ores/coal":
-	{
-		"smithing": 8
-	},
-	"#forge:ores/copper":
-	{
-		"smithing": 7.5
-	},
-	"#forge:ores/diamond":
-	{
-		"smithing": 35
-	},
-	"#forge:ores/emerald":
-	{
-		"smithing": 60
-	},
-	"#forge:ores/netherite_scrap":
-	{
-		"smithing": 333
-	},
-	"#forge:ores/gold":
-	{
-		"smithing": 18
-	},
-	"#forge:ores/iron":
-	{
-		"smithing": 12
-	},
-	"#forge:ores/lapis":
-	{
-		"smithing": 25
-	},
-	"#forge:ores/nickel":
-	{
-		"smithing": 8.5
-	},
-	"#forge:ores/quartz":
-	{
-		"smithing": 8
-	},
-	"#forge:ores/redstone":
-	{
-		"smithing": 15
-	},
-	"#forge:ores/silver":
-	{
-		"smithing": 11
-	},
-	"#forge:ores/tin":
-	{
-		"smithing": 6.5
-	},
-	"#forge:ores/zinc":
-	{
-		"smithing": 16
-	},
-	"#forge:sandstone":
-	{
-		"smithing": 3
-	},
-	"#forge:stone":
-	{
+	"#forge:cobblestone": {
 		"smithing": 1
 	},
-	"#minecraft:logs":
-	{
-		"smithing": 0.25
+	"#forge:dusts/hop_graphite": {
+		"smithing": 22
 	},
-	"appliedenergistics2:certus_quartz_dust":
-	{
-		"smithing": 16
-	},
-	"appliedenergistics2:gold_dust":
-	{
-		"smithing": 16
-	},
-	"appliedenergistics2:iron_dust":
-	{
-		"smithing": 24
-	},
-	"appliedenergistics2:nether_quartz_dust":
-	{
-		"smithing": 12
-	},
-	"aquaculture:tin_can":
-	{
-		"smithing": 12
-	},
-	"ars_nouveau:arcane_ore":
-	{
+	"#forge:dusts/redstone": {
 		"smithing": 15
 	},
-	"astralsorcery:aquamarine_sand_ore":
-	{
+	"#forge:dusts/saltpeter": {
+		"smithing": 14,
+		"magic": 2
+	},
+	"#forge:gems/agate": {
+		"smithing": 18
+	},
+	"#forge:gems/alexandrite": {
+		"smithing": 18
+	},
+	"#forge:gems/amber": {
+		"smithing": 12,
+		"magic": 2
+	},
+	"#forge:gems/amethyst": {
+		"smithing": 18
+	},
+	"#forge:gems/ametrine": {
+		"smithing": 18
+	},
+	"#forge:gems/ammolite": {
+		"smithing": 18
+	},
+	"#forge:gems/amythest": {
+		"smithing": 35
+	},
+	"#forge:gems/apatite": {
+		"smithing": 18
+	},
+	"#forge:gems/aquamarine": {
 		"smithing": 15,
 		"magic": 2
 	},
-	"astralsorcery:starmetal_ore":
-	{
-		"smithing": 18,
-		"magic": 20
-	},
-	"autumnity:maple_log":
-	{
-		"smithing": 0.25
-	},
-	"autumnity:sappy_maple_log":
-	{
-		"smithing": 0.25
-	},
-	"biggerreactors:blutonium_dust":
-	{
+	"#forge:gems/benitoite": {
 		"smithing": 18
 	},
-	"biggerreactors:cyanite_dust":
-	{
+	"#forge:gems/black_diamond": {
 		"smithing": 18
 	},
-	"biggerreactors:graphite_dust":
-	{
-		"smithing": 12
+	"#forge:gems/carnelian": {
+		"smithing": 18
 	},
-	"biggerreactors:ludicrite_dust":
-	{
+	"#forge:gems/cats_eye": {
+		"smithing": 18
+	},
+	"#forge:gems/chaos": {
+		"smithing": 18
+	},
+	"#forge:gems/chrysoprase": {
+		"smithing": 18
+	},
+	"#forge:gems/citrine": {
+		"smithing": 18
+	},
+	"#forge:gems/coral": {
+		"smithing": 18
+	},
+	"#forge:gems/diamond": {
 		"smithing": 35
 	},
-	"bigreactors:anglesite_ore":
-	{
-		"smithing": 18
-	},
-	"bigreactors:benitoite_ore":
-	{
-		"smithing": 18
-	},
-	"bigreactors:yellorite_ore":
-	{
-		"smithing": 18
-	},
-	"bigreactors:yellorium_dust":
-	{
-		"smithing": 16
-	},
-	"biomesoplenty:cherry_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:dead_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:fir_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:hellbark_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:jacaranda_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:magic_log":
-	{
-		"smithing": 0.15,
-		"magic": 0.05
-	},
-	"biomesoplenty:mahogany_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:mud_ball":
-	{
-		"smithing": 1.2
-	},
-	"biomesoplenty:palm_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:redwood_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:umbran_log":
-	{
-		"smithing": 0.25
-	},
-	"biomesoplenty:white_sand":
-	{
-		"smithing": 1
-	},
-	"biomesoplenty:willow_log":
-	{
-		"smithing": 0.25
-	},
-	"bloodmagic:goldsand":
-	{
-		"smithing": 16
-	},
-	"bloodmagic:ironsand":
-	{
-		"smithing": 12
-	},
-	"bloodmagic:sand_hellforged":
-	{
-		"smithing": 18,
-		"magic": 4
-	},
-	"bloodmagic:sand_netherite":
-	{
+	"#forge:gems/emerald": {
 		"smithing": 60
 	},
-	"bno:netheraluminum_ore":
-	{
-		"smithing": 12
+	"#forge:gems/euclase": {
+		"smithing": 18
 	},
-	"bno:nethercoal_ore":
-	{
-		"smithing": 8
+	"#forge:gems/fluorite": {
+		"smithing": 15
 	},
-	"bno:nethercopper_ore":
-	{
-		"smithing": 7
+	"#forge:gems/garnet": {
+		"smithing": 18
 	},
-	"bno:netherdiamond_ore":
-	{
-		"smithing": 35
+	"#forge:gems/green_sapphire": {
+		"smithing": 18
 	},
-	"bno:netheremerald_ore":
-	{
-		"smithing": 60
+	"#forge:gems/heliodor": {
+		"smithing": 18
 	},
-	"bno:netheriron_ore":
-	{
-		"smithing": 12
+	"#forge:gems/iolite": {
+		"smithing": 18
 	},
-	"bno:netherlapis_ore":
-	{
+	"#forge:gems/jade": {
+		"smithing": 18
+	},
+	"#forge:gems/jasper": {
+		"smithing": 18
+	},
+	"#forge:gems/kunzite": {
+		"smithing": 18
+	},
+	"#forge:gems/kyanite": {
+		"smithing": 18
+	},
+	"#forge:gems/lapis": {
 		"smithing": 25
 	},
-	"bno:netherlead_ore":
-	{
+	"#forge:gems/lepidolite": {
 		"smithing": 18
 	},
-	"bno:nethernickel_ore":
-	{
-		"smithing": 28
+	"#forge:gems/malachite": {
+		"smithing": 18
 	},
-	"bno:netherosmium_ore":
-	{
-		"smithing": 12
-	},
-	"bno:netherredstone_ore":
-	{
+	"#forge:gems/mana": {
 		"smithing": 15
 	},
-	"bno:nethersilver_ore":
-	{
+	"#forge:gems/moldavit": {
 		"smithing": 18
 	},
-	"bno:nethertin_ore":
-	{
-		"smithing": 12
-	},
-	"bno:netheruranium_ore":
-	{
-		"smithing": 18
-	},
-	"charm:nether_gold_deposit":
-	{
-		"smithing": 22
-	},
-	"charm:pig_iron_ore":
-	{
-		"smithing": 22
-	},
-	"create:crushed_aluminum_ore":
-	{
-		"smithing": 10
-	},
-	"create:crushed_brass_ore":
-	{
-		"smithing": 23.5
-	},
-	"create:crushed_copper_ore":
-	{
-		"smithing": 6.5
-	},
-	"create:crushed_gold_ore":
-	{
-		"smithing": 17
-	},
-	"create:crushed_iron_ore":
-	{
-		"smithing": 11
-	},
-	"create:crushed_lead_ore":
-	{
-		"smithing": 16
-	},
-	"create:crushed_nickel_ore":
-	{
-		"smithing": 26
-	},
-	"create:crushed_osmium_ore":
-	{
-		"smithing": 10
-	},
-	"create:crushed_platinum_ore":
-	{
-		"smithing": 26
-	},
-	"create:crushed_silver_ore":
-	{
-		"smithing": 16
-	},
-	"create:crushed_tin_ore":
-	{
-		"smithing": 11
-	},
-	"create:crushed_uranium_ore":
-	{
-		"smithing": 18
-	},
-	"create:crushed_zinc_ore":
-	{
-		"smithing": 15
-	},
-	"druidcraft:amber_ore":
-	{
+	"#forge:gems/moonstone": {
 		"smithing": 12,
 		"magic": 2
 	},
-	"druidcraft:fiery_glass_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"druidcraft:moonstone_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"druidcraft:rockroot_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"eidolon:pewter_blend":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"elementalcraft:crystalore":
-	{
-		"smithing": 12
-	},
-	"elementalcraft:pure_ore":
-	{
-		"smithing": 12
-	},
-	"endreborn:end_wolframium_ore":
-	{
-		"smithing": 14
-	},
-	"endreborn:quartz_ore":
-	{
-		"smithing": 13
-	},
-	"endreborn:wolframium_horse_armor":
-	{
-		"smithing": 20
-	},
-	"endreborn:wolframium_ore":
-	{
-		"smithing": 12
-	},
-	"enigmaticlegacy:etherium_ore":
-	{
+	"#forge:gems/morganite": {
 		"smithing": 18
 	},
-	"forbidden_arcanus:arcane_crystal":
-	{
-		"smithing": 12,
-		"magic": 6
-	},
-	"forbidden_arcanus:arcane_crystal_ore":
-	{
-		"smithing": 12,
-		"magic": 6
-	},
-	"forbidden_arcanus:dark_runestone":
-	{
-		"smithing": 10,
-		"magic": 12
-	},
-	"forbidden_arcanus:edelwood_log":
-	{
-		"smithing": 8,
-		"magic": 16
-	},
-	"forbidden_arcanus:obsidian_with_iron":
-	{
-		"smithing": 12,
-		"magic": 6
-	},
-	"forbidden_arcanus:runestone":
-	{
-		"smithing": 8,
-		"magic": 10
-	},
-	"good_nights_sleep:necrum_ore":
-	{
-		"smithing": 18,
-		"magic": 4
-	},
-	"good_nights_sleep:negatite_ore":
-	{
-		"smithing": 10,
-		"magic": 20
-	},
-	"good_nights_sleep:positite_ore":
-	{
-		"smithing": 10,
-		"magic": 20
-	},
-	"good_nights_sleep:rainbow_ore":
-	{
-		"smithing": 18,
-		"magic": 4
-	},
-	"good_nights_sleep:zitrite_ore":
-	{
-		"smithing": 12,
-		"magic": 4
-	},
-	"iceandfire:amythest_ore":
-	{
-		"smithing": 35
-	},
-	"iceandfire:copper_ore":
-	{
-		"smithing": 7
-	},
-	"iceandfire:frozen_cobblestone":
-	{
-		"smithing": 2
-	},
-	"iceandfire:frozen_grass_path":
-	{
-		"smithing": 2
-	},
-	"iceandfire:frozen_stone":
-	{
-		"smithing": 2
-	},
-	"iceandfire:sapphire_ore":
-	{
-		"smithing": 35
-	},
-	"iceandfire:silver_ore":
-	{
+	"#forge:gems/onyx": {
 		"smithing": 18
 	},
-	"immersiveengineering:dust_gold":
-	{
-		"smithing": 16
+	"#forge:gems/opal": {
+		"smithing": 18
 	},
-	"immersiveengineering:dust_hop_graphite":
-	{
-		"smithing": 22
+	"#forge:gems/pearl": {
+		"smithing": 18
 	},
-	"immersiveengineering:dust_iron":
-	{
-		"smithing": 12
+	"#forge:gems/peridot": {
+		"smithing": 18
 	},
-	"mekanism:dust_netherite":
-	{
-		"smithing": 60
+	"#forge:gems/phosphophyllite": {
+		"smithing": 18
 	},
-	"mekanism:dust_osmium":
-	{
+	"#forge:gems/pyrope": {
+		"smithing": 18
+	},
+	"#forge:gems/quartz": {
 		"smithing": 8
 	},
-	"mekanism:dust_quartz":
-	{
+	"#forge:gems/rose_quartz": {
+		"smithing": 18
+	},
+	"#forge:gems/ruby": {
+		"smithing": 18
+	},
+	"#forge:gems/sapphire": {
+		"smithing": 35
+	},
+	"#forge:gems/sodalite": {
+		"smithing": 18
+	},
+	"#forge:gems/spinel": {
+		"smithing": 18
+	},
+	"#forge:gems/sunstone": {
+		"smithing": 18
+	},
+	"#forge:gems/tanzanite": {
+		"smithing": 18
+	},
+	"#forge:gems/tektite": {
+		"smithing": 18
+	},
+	"#forge:gems/topaz": {
+		"smithing": 18
+	},
+	"#forge:gems/turquoise": {
+		"smithing": 18
+	},
+	"#forge:gems/yellow_diamond": {
+		"smithing": 18
+	},
+	"#forge:gems/zircon": {
+		"smithing": 18
+	},
+	"#forge:glass": {
+		"smithing": 1
+	},
+	"#forge:gravel": {
+		"smithing": 1
+	},
+	"#forge:ingots/brass": {
+		"smithing": 22
+	},
+	"#forge:ingots/aluminum": {
+		"smithing": 12.5
+	},
+	"#forge:ingots/aluminum_steel": {
+		"smithing": 18
+	},
+	"#forge:ingots/arcane_gold": {
+		"smithing": 12,
+		"magic": 6
+	},
+	"#forge:ingots/azure_electrum": {
+		"smithing": 22
+	},
+	"#forge:ingots/azure_silver": {
 		"smithing": 16
 	},
-	"mekanism:fluorite_ore":
-	{
-		"smithing": 15
-	},
-	"mekanism:osmium_ore":
-	{
+	"#forge:ingots/bauxite": {
 		"smithing": 12
 	},
-	"minecraft:acacia_log":
-	{
-		"smithing": 0.25
+	"#forge:ingots/bismuth_brass": {
+		"smithing": 18
 	},
-	"minecraft:ancient_debris":
-	{
-		"smithing": 60
-	},
-	"minecraft:birch_log":
-	{
-		"smithing": 0.25
-	},
-	"minecraft:black_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:blue_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:brown_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:chainmail_boots":
-	{
-		"smithing": 6
-	},
-	"minecraft:chainmail_chestplate":
-	{
+	"#forge:ingots/bismuth_ore": {
 		"smithing": 12
 	},
-	"minecraft:chainmail_helmet":
-	{
-		"smithing": 7.5
+	"#forge:ingots/bismuth_steel": {
+		"smithing": 18
 	},
-	"minecraft:chainmail_leggings":
-	{
-		"smithing": 10.5
+	"#forge:ingots/blaze_gold": {
+		"smithing": 18
 	},
-	"minecraft:charcoal":
-	{
-		"smithing": 8
-	},
-	"minecraft:clay":
-	{
-		"smithing": 6,
-		"crafting": 14
-	},
-	"minecraft:clay_ball":
-	{
+	"#forge:ingots/brick": {
 		"smithing": 1.5,
 		"crafting": 3.5
 	},
-	"minecraft:coal":
-	{
-		"smithing": 8
+	"#forge:ingots/cloggrum": {
+		"smithing": 12
 	},
-	"minecraft:cobblestone":
-	{
-		"smithing": 0.5
+	"#forge:ingots/copper": {
+		"smithing": 7.5
 	},
-	"minecraft:cyan_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:dark_oak_log":
-	{
-		"smithing": 0.25
-	},
-	"minecraft:golden_axe":
-	{
-		"smithing": 6
-	},
-	"minecraft:golden_boots":
-	{
-		"smithing": 8
-	},
-	"minecraft:golden_chestplate":
-	{
+	"#forge:ingots/crimson_iron": {
 		"smithing": 16
 	},
-	"minecraft:golden_helmet":
-	{
-		"smithing": 10
+	"#forge:ingots/crimson_steel": {
+		"smithing": 22
 	},
-	"minecraft:golden_hoe":
-	{
+	"#forge:ingots/cyanite": {
+		"smithing": 18
+	},
+	"#forge:ingots/froststeel": {
+		"smithing": 12
+	},
+	"#forge:ingots/gold": {
+		"smithing": 18
+	},
+	"#forge:ingots/graphite": {
+		"smithing": 12
+	},
+	"#forge:ingots/hellforged": {
+		"smithing": 18,
+		"magic": 4
+	},
+	"#forge:ingots/iron": {
+		"smithing": 12
+	},
+	"#forge:ingots/lead": {
+		"smithing": 18
+	},
+	"#forge:ingots/ludicrite": {
+		"smithing": 35
+	},
+	"#forge:ingots/nether_brick": {
+		"smithing": 0.25
+	},
+	"#forge:ingots/netherite": {
+		"smithing": 1400
+	},
+	"#forge:ingots/nickel": {
+		"smithing": 8.5
+	},
+	"#forge:ingots/obsidian": {
+		"smithing": 50
+	},
+	"#forge:ingots/osmium": {
+		"smithing": 12
+	},
+	"#forge:ingots/pewter": {
+		"smithing": 12,
+		"magic": 2
+	},
+	"#forge:ingots/platinum": {
+		"smithing": 28
+	},
+	"#forge:ingots/redstone_alloy": {
+		"smithing": 18
+	},
+	"#forge:ingots/refined_glowstone": {
+		"smithing": 16
+	},
+	"#forge:ingots/refined_obsidian": {
+		"smithing": 60
+	},
+	"#forge:ingots/regalium": {
+		"smithing": 12
+	},
+	"#forge:ingots/silver": {
+		"smithing": 11
+	},
+	"#forge:ingots/steel": {
+		"smithing": 16
+	},
+	"#forge:ingots/tin": {
+		"smithing": 6.5
+	},
+	"#forge:ingots/tyrian_steel": {
+		"smithing": 28
+	},
+	"#forge:ingots/uranium": {
+		"smithing": 18
+	},
+	"#forge:ingots/utherium": {
+		"smithing": 12
+	},
+	"#forge:ingots/yellorium": {
+		"smithing": 16
+	},
+	"#forge:ingots/zinc": {
+		"smithing": 16
+	},
+	"#forge:nuggets/gold": {
+		"smithing": 1.95
+	},
+	"#forge:nuggets/iron": {
+		"smithing": 1.3
+	},
+	"#forge:plastic": {
 		"smithing": 4
 	},
-	"minecraft:golden_horse_armor":
-	{
-		"smithing": 100
-	},
-	"minecraft:golden_leggings":
-	{
-		"smithing": 14
-	},
-	"minecraft:golden_pickaxe":
-	{
-		"smithing": 6
-	},
-	"minecraft:golden_shovel":
-	{
-		"smithing": 2
-	},
-	"minecraft:golden_sword":
-	{
-		"smithing": 4
-	},
-	"minecraft:gray_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:green_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:iron_axe":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:iron_boots":
-	{
-		"smithing": 2
-	},
-	"minecraft:iron_chestplate":
-	{
-		"smithing": 4
-	},
-	"minecraft:iron_helmet":
-	{
-		"smithing": 2.5
-	},
-	"minecraft:iron_hoe":
-	{
-		"smithing": 1
-	},
-	"minecraft:iron_horse_armor":
-	{
-		"smithing": 25
-	},
-	"minecraft:iron_leggings":
-	{
-		"smithing": 3.5
-	},
-	"minecraft:iron_pickaxe":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:iron_shovel":
-	{
-		"smithing": 0.5
-	},
-	"minecraft:iron_sword":
-	{
-		"smithing": 1
-	},
-	"minecraft:jungle_log":
-	{
-		"smithing": 0.25
-	},
-	"minecraft:light_blue_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:light_gray_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:lime_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:log":
-	{
-		"smithing": 0.25
-	},
-	"minecraft:magenta_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:nether_bricks":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:netherrack":
-	{
-		"smithing": 0.25
-	},
-	"minecraft:oak_log":
-	{
-		"smithing": 0.25
-	},
-	"minecraft:orange_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:pink_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:polished_blackstone_bricks":
-	{
-		"smithing": 2.5
-	},
-	"minecraft:purple_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:red_sand":
-	{
-		"smithing": 1.2
-	},
-	"minecraft:red_sandstone":
-	{
-		"smithing": 3.6
-	},
-	"minecraft:red_terracotta":
-	{
-		"smithing": 1.5
-	},
-	"minecraft:sand":
-	{
-		"smithing": 1
-	},
-	"minecraft:sandstone":
-	{
+	"#forge:sandstone": {
 		"smithing": 3
 	},
-	"minecraft:spruce_log":
-	{
-		"smithing": 0.25
+	"#forge:silicon": {
+		"smithing": 16
 	},
-	"minecraft:stone":
-	{
+	"#forge:stone": {
 		"smithing": 1
 	},
-	"minecraft:stone_bricks":
-	{
+	"#forge:storage_blocks/inferium_essence": {
+		"smithing": 12,
+		"magic": 2
+	},
+	"#forge:storage_blocks/prosperity_shard": {
+		"smithing": 12,
+		"magic": 2
+	},
+	"#forge:storage_blocks/soulium_dust": {
+		"smithing": 12,
+		"magic": 2
+	},
+	"#forge:storage_blocks/uraninite": {
+		"smithing": 18
+	},
+	"#forge:terracottas": {
+		"smithing": 1.5
+	},
+	"#minecraft:coals": {
+		"smithing": 8
+	},
+	"#minecraft:stone_bricks": {
 		"smithing": 1
 	},
-	"minecraft:terracotta":
-	{
+	"eidolon:enchanted_ash": {
+		"smithing": 1,
+		"magic": 2
+	},
+	"minecraft:cracked_nether_bricks": {
 		"smithing": 1.5
 	},
-	"minecraft:white_terracotta":
-	{
-		"smithing": 1.5
+	"minecraft:cracked_polished_blackstone_bricks": {
+		"smithing": 2.5
 	},
-	"minecraft:yellow_terracotta":
-	{
-		"smithing": 1.5
+	"minecraft:netherite_scrap": {
+		"smithing": 333
 	},
-	"mysticalagradditions:end_inferium_ore":
-	{
-		"smithing": 12,
-		"magic": 2
+	"minecraft:smooth_stone": {
+		"smithing": 1
 	},
-	"mysticalagradditions:end_prosperity_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"mysticalagradditions:nether_inferium_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"mysticalagradditions:nether_prosperity_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"mysticalagriculture:inferium_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"mysticalagriculture:prosperity_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"mysticalagriculture:soulium_ore":
-	{
-		"smithing": 12,
-		"magic": 2
-	},
-	"powah:uraninite_ore":
-	{
-		"smithing": 14
-	},
-	"powah:uraninite_ore_dense":
-	{
-		"smithing": 18
-	},
-	"powah:uraninite_ore_poor":
-	{
-		"smithing": 10
-	},
-	"powah:uraninite_raw":
-	{
-		"smithing": 14
-	},
-	"powah:uraninite_raw_dense":
-	{
-		"smithing": 18
-	},
-	"powah:uraninite_raw_poor":
-	{
-		"smithing": 10
-	},
-	"rats:cheese_ore":
-	{
-		"smithing": 8
-	},
-	"rats:marbled_cheese_raw":
-	{
-		"smithing": 12
-	},
-	"rats:oratchalcum_ore":
-	{
-		"smithing": 18
-	},
-	"rats:ratlantean_gem_ore":
-	{
-		"smithing": 35
-	},
-	"silentgear:azure_electrum_dust":
-	{
-		"smithing": 22
-	},
-	"silentgear:azure_silver_chunks":
-	{
-		"smithing": 16
-	},
-	"silentgear:azure_silver_dust":
-	{
-		"smithing": 16
-	},
-	"silentgear:azure_silver_ore":
-	{
-		"smithing": 16
-	},
-	"silentgear:blaze_gold_dust":
-	{
-		"smithing": 18
-	},
-	"silentgear:crimson_iron_chunks":
-	{
-		"smithing": 16
-	},
-	"silentgear:crimson_iron_dust":
-	{
-		"smithing": 16
-	},
-	"silentgear:crimson_iron_ore":
-	{
-		"smithing": 16
-	},
-	"silentgear:crimson_steel_dust":
-	{
-		"smithing": 22
-	},
-	"silentgems:agate_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:alexandrite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:amber_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:ametrine_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:ammolite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:apatite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:aquamarine_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:benitoite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:black_diamond_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:carnelian_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:cats_eye_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:chaos_gold_dust":
-	{
-		"smithing": 18
-	},
-	"silentgems:chaos_iron_dust":
-	{
-		"smithing": 18
-	},
-	"silentgems:chaos_ore":
-	{
-		"smithing": 8
-	},
-	"silentgems:chaos_silver_dust":
-	{
-		"smithing": 18
-	},
-	"silentgems:chrysoprase_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:citrine_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:coral_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:ender_ore":
-	{
-		"smithing": 12
-	},
-	"silentgems:euclase_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:fluorite_ore":
-	{
-		"smithing": 15
-	},
-	"silentgems:garnet_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:green_sapphire_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:heliodor_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:iolite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:jade_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:jasper_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:kunzite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:kyanite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:lepidolite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:malachite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:moldavite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:moonstone_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:morganite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:onyx_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:opal_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:pearl_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:peridot_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:phosphophyllite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:pyrope_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:rose_quartz_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:ruby_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:sapphire_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:sodalite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:spinel_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:sunstone_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:tanzanite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:tektite_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:topaz_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:turquoise_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:yellow_diamond_ore":
-	{
-		"smithing": 18
-	},
-	"silentgems:zircon_ore":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:aluminum_dust":
-	{
-		"smithing": 8
-	},
-	"silents_mechanisms:aluminum_steel_dust":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:bauxite_chunks":
-	{
-		"smithing": 8
-	},
-	"silents_mechanisms:bauxite_ore":
-	{
-		"smithing": 12
-	},
-	"silents_mechanisms:bismuth_brass_dust":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:bismuth_chunks":
-	{
-		"smithing": 8
-	},
-	"silents_mechanisms:bismuth_dust":
-	{
-		"smithing": 8
-	},
-	"silents_mechanisms:bismuth_ore":
-	{
-		"smithing": 12
-	},
-	"silents_mechanisms:bismuth_steel_dust":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:brass_dust":
-	{
-		"smithing": 22
-	},
-	"silents_mechanisms:copper_chunks":
-	{
-		"smithing": 7
-	},
-	"silents_mechanisms:gold_chunks":
-	{
-		"smithing": 16
-	},
-	"silents_mechanisms:iron_chunks":
-	{
-		"smithing": 12
-	},
-	"silents_mechanisms:lead_chunks":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:nickel_chunks":
-	{
-		"smithing": 28
-	},
-	"silents_mechanisms:platinum_chunks":
-	{
-		"smithing": 28
-	},
-	"silents_mechanisms:platinum_dust":
-	{
-		"smithing": 28
-	},
-	"silents_mechanisms:platinum_ore":
-	{
-		"smithing": 28
-	},
-	"silents_mechanisms:redstone_alloy_dust":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:silver_chunks":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:steel_dust":
-	{
-		"smithing": 16
-	},
-	"silents_mechanisms:uranium_chunks":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:uranium_dust":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:uranium_ore":
-	{
-		"smithing": 18
-	},
-	"silents_mechanisms:zinc_chunks":
-	{
-		"smithing": 12
-	},
-	"silents_mechanisms:zinc_dust":
-	{
-		"smithing": 12
-	},
-	"silents_mechanisms:zinc_ore":
-	{
-		"smithing": 16
-	},
-	"silentsgems:amethyst_ore":
-	{
-		"smithing": 18
-	},
-	"theabyss:abyssingot":
-	{
-		"smithing": 8
-	},
-	"theabyss:unactivefusioningot":
-	{
-		"smithing": 18
-	},
-	"thermal:apatite_ore":
-	{
-		"smithing": 6
-	},
-	"thermal:bronze_dust":
-	{
-		"smithing": 18
-	},
-	"thermal:cinnabar_ore":
-	{
-		"smithing": 12
-	},
-	"thermal:constantan_dust":
-	{
-		"smithing": 18
-	},
-	"thermal:copper_dust":
-	{
-		"smithing": 7
-	},
-	"thermal:copper_ore":
-	{
-		"smithing": 7
-	},
-	"thermal:electrum_dust":
-	{
-		"smithing": 18
-	},
-	"thermal:enderium_dust":
-	{
-		"smithing": 28,
-		"magic": 2
-	},
-	"thermal:gold_dust":
-	{
-		"smithing": 16
-	},
-	"thermal:invar_dust":
-	{
-		"smithing": 22
-	},
-	"thermal:iron_dust":
-	{
-		"smithing": 12
-	},
-	"thermal:lead_dust":
-	{
-		"smithing": 18
-	},
-	"thermal:lead_ore":
-	{
-		"smithing": 18
-	},
-	"thermal:lumium_dust":
-	{
-		"smithing": 18
-	},
-	"thermal:nickel_dust":
-	{
-		"smithing": 28
-	},
-	"thermal:nickel_ore":
-	{
-		"smithing": 28
-	},
-	"thermal:niter_ore":
-	{
-		"smithing": 12
-	},
-	"thermal:quartz_dust":
-	{
-		"smithing": 16
-	},
-	"thermal:rubber":
-	{
-		"smithing": 8
-	},
-	"thermal:ruby_ore":
-	{
-		"smithing": 18
-	},
-	"thermal:sapphire_ore":
-	{
-		"smithing": 18
-	},
-	"thermal:signalum_dust":
-	{
-		"smithing": 22
-	},
-	"thermal:silver_dust":
-	{
-		"smithing": 18
-	},
-	"thermal:silver_ore":
-	{
-		"smithing": 18
-	},
-	"thermal:sulfur_ore":
-	{
-		"smithing": 12
-	},
-	"thermal:tin_dust":
-	{
-		"smithing": 12
-	},
-	"thermal:tin_ore":
-	{
-		"smithing": 12
-	},
-	"tmechworks:aluminum_ore":
-	{
-		"smithing": 12
-	},
-	"tmechworks:copper_ore":
-	{
-		"smithing": 7
-	},
-	"treemendous:alder_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:ash_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:beech_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:cedar_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:cherry_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:chestnut_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:douglas_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:elm_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:fir_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:japanese_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:juniper_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:larch_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:linden_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:magnolia_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:maple_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:pine_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:plane_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:pomegranate_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:poplar_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:rainbow_eucalyptus_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:robinia_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:walnut_log":
-	{
-		"smithing": 0.25
-	},
-	"treemendous:willow_log":
-	{
-		"smithing": 0.25
-	},
-	"undergarden:cloggrum_ore":
-	{
-		"smithing": 12
-	},
-	"undergarden:coal_ore":
-	{
-		"smithing": 8
-	},
-	"undergarden:diamond_ore":
-	{
-		"smithing": 35
-	},
-	"undergarden:froststeel_ore":
-	{
-		"smithing": 12
-	},
-	"undergarden:gold_ore":
-	{
-		"smithing": 18
-	},
-	"undergarden:iron_ore":
-	{
-		"smithing": 12
-	},
-	"undergarden:regalium_ore":
-	{
-		"smithing": 12
-	},
-	"undergarden:utherium_ore":
-	{
-		"smithing": 12
-	},
-	"woot:si_dust":
-	{
-		"smithing": 12
-	},
-	"#forge:dusts":
-	{
-		"smithing": 0
+	"minecraft:terracotta": {
+		"smithing": 6,
+		"crafting": 14
 	}
 }

--- a/src/main/resources/data/forge/tags/items/terracottas.json
+++ b/src/main/resources/data/forge/tags/items/terracottas.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cyan_glazed_terracotta",
+    "minecraft:black_glazed_terracotta",
+    "minecraft:blue_glazed_terracotta",
+    "minecraft:brown_glazed_terracotta",
+    "minecraft:gray_glazed_terracotta",
+    "minecraft:green_glazed_terracotta",
+    "minecraft:light_blue_glazed_terracotta",
+    "minecraft:light_gray_glazed_terracotta",
+    "minecraft:lime_glazed_terracotta",
+    "minecraft:magenta_glazed_terracotta",
+    "minecraft:orange_glazed_terracotta",
+    "minecraft:pink_glazed_terracotta",
+    "minecraft:purple_glazed_terracotta",
+    "minecraft:red_glazed_terracotta",
+    "minecraft:white_glazed_terracotta",
+    "minecraft:yellow_glazed_terracotta"
+  ]
+}


### PR DESCRIPTION
Ref #229
- Update FurnaceHandler to use result instead of input
- Update Mixins with new FurnaceHandler parameters (remove input itemstack)
- Update Autovalues for Cooking result instead of input
- Update templated configs for cooking/smelt to reflect result instead of input
- Update templated smelt config to use tags where practical instead of items
  - See #216 for progress on getting external mods to update to using tags for items not currently captured
- Added Forge Tag to encapsulate Minecraft Terracotta blocks
- General cleanup particularly unused imports