### PR TITLE
Add Github Action and Supporting Changelog

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -1,0 +1,119 @@
+name: Build and upload mod
+on:
+  push:
+    branches:
+      - '1.16'
+  release:
+    types: [ published ]
+    branches:
+      - '1.16'
+
+jobs:
+
+  path:
+    if: ${{ contains(github.event.head_commit.message, 'version bump for release') && github.event_name != 'release' }}
+    name: Generate file path
+    runs-on: ubuntu-latest
+    outputs:
+      mod_name: ${{steps.moddetails.outputs.mod_name}}
+      mod_version: ${{steps.moddetails.outputs.mod_version}}
+      java_version: ${{steps.moddetails.outputs.java_version}}
+      mc_patch_version: ${{steps.patchversion.outputs.mc_patch_version}}
+      mc_minor_version: ${{steps.minorversion.outputs.mc_minor_version}}
+      file_path: ${{steps.filepath.outputs.file_path}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get Details
+        id: moddetails
+        run: |
+          echo "mod_name=$(cat ./build.gradle | sed -n 's/archivesBaseName \= //p' | tr -d "'")" >> $GITHUB_OUTPUT
+          echo "mod_version=$(cat ./build.gradle | sed -n 's/version \= //p' | tr -d "'")" >> $GITHUB_OUTPUT
+          echo "java_version=$(cat ./build.gradle | grep -o -P '(?<=JavaLanguageVersion.of\().*(?=\))')" >> $GITHUB_OUTPUT
+      - name: MC Patch Version
+        id: patchversion
+        run: echo "mc_patch_version=$(echo ${{ steps.moddetails.outputs.mod_version }} | awk -F- '{ print $1 }')" >> $GITHUB_OUTPUT
+      - name: MC Minor Version
+        id: minorversion
+        run: echo "mc_minor_version=$(echo ${{ steps.patchversion.outputs.mc_patch_version }} | awk -F. '{ print $1"."$2 }')" >> $GITHUB_OUTPUT
+      - name: Get Details
+        id: filepath
+        run: echo "file_path=./build/libs/${{ steps.moddetails.outputs.mod_name }}-${{ steps.moddetails.outputs.mod_version }}.jar" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build and cache
+    runs-on: ubuntu-latest
+    needs: [ path ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '${{ needs.path.outputs.java_version }}'
+          distribution: 'adopt'
+          cache: 'gradle'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build
+        run: ./gradlew :build
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ needs.path.outputs.file_path }}
+            CHANGELOG.md
+          key: ${{ github.sha }}
+
+  curseforge:
+    name: Upload to ModRepo
+    runs-on: ubuntu-latest
+    needs: [ path,build ]
+    steps:
+      - name: Restore Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ needs.path.outputs.file_path }}
+            CHANGELOG.md
+          key: ${{ github.sha }}
+      - name: Upload to CurseForge
+        if: ${{ vars.MODREPO == 'curseforge' || vars.MODREPO == 'both' }}
+        uses: Kir-Antipov/mc-publish@v3.2
+        with:
+          curseforge-id: 353935
+          curseforge-token: ${{ secrets.curseforge_api }}
+
+          files-primary: ${{ needs.path.outputs.file_path }}
+
+          name: ${{ needs.path.outputs.mod_name }}-${{ needs.path.outputs.mod_version }}
+          version: ${{ needs.path.outputs.mod_version }}
+          changelog-file: CHANGELOG.md
+
+          loaders: |
+            forge
+          game-versions: |
+            ${{ needs.path.outputs.mc_minor_version }}
+            ${{ needs.path.outputs.mc_patch_version }}
+          java: |
+            ${{ needs.path.outputs.java_version }}
+      - name: Upload to Modrinth
+        if: ${{ vars.MODREPO == 'modrinth' || vars.MODREPO == 'both' }}
+        uses: Kir-Antipov/mc-publish@v3.2
+        with:
+          modrinth-id: KFQYC1Uy
+          modrinth-token: ${{ secrets.curseforge_api }}
+
+          files-primary: ${{ needs.path.outputs.file_path }}
+
+          name: ${{ needs.path.outputs.mod_name }}-${{ needs.path.outputs.mod_version }}
+          version: ${{ needs.path.outputs.mod_version }}
+          changelog-file: CHANGELOG.md
+
+          loaders: |
+            forge
+          game-versions: |
+            ${{ needs.path.outputs.mc_minor_version }}
+            ${{ needs.path.outputs.mc_patch_version }}
+          java: |
+            ${{ needs.path.outputs.java_version }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -9,8 +9,7 @@ on:
       - '1.16'
 
 jobs:
-
-  path:
+  setup:
     if: ${{ contains(github.event.head_commit.message, 'version bump for release') && github.event_name != 'release' }}
     name: Generate file path
     runs-on: ubuntu-latest
@@ -43,14 +42,14 @@ jobs:
   build:
     name: Build and cache
     runs-on: ubuntu-latest
-    needs: [ path ]
+    needs: [ setup ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '${{ needs.path.outputs.java_version }}'
+          java-version: '${{ needs.setup.outputs.java_version }}'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Grant execute permission for gradlew
@@ -61,20 +60,20 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ${{ needs.path.outputs.file_path }}
+            ${{ needs.setup.outputs.file_path }}
             CHANGELOG.md
           key: ${{ github.sha }}
 
-  curseforge:
+  upload:
     name: Upload to ModRepo
     runs-on: ubuntu-latest
-    needs: [ path,build ]
+    needs: [ setup,build ]
     steps:
       - name: Restore Cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ needs.path.outputs.file_path }}
+            ${{ needs.setup.outputs.file_path }}
             CHANGELOG.md
           key: ${{ github.sha }}
       - name: Upload to CurseForge
@@ -84,19 +83,19 @@ jobs:
           curseforge-id: 353935
           curseforge-token: ${{ secrets.curseforge_api }}
 
-          files-primary: ${{ needs.path.outputs.file_path }}
+          files-primary: ${{ needs.setup.outputs.file_path }}
 
-          name: ${{ needs.path.outputs.mod_name }}-${{ needs.path.outputs.mod_version }}
-          version: ${{ needs.path.outputs.mod_version }}
+          name: ${{ needs.setup.outputs.mod_name }}-${{ needs.setup.outputs.mod_version }}
+          version: ${{ needs.setup.outputs.mod_version }}
           changelog-file: CHANGELOG.md
 
           loaders: |
             forge
           game-versions: |
-            ${{ needs.path.outputs.mc_minor_version }}
-            ${{ needs.path.outputs.mc_patch_version }}
+            ${{ needs.setup.outputs.mc_minor_version }}
+            ${{ needs.setup.outputs.mc_patch_version }}
           java: |
-            ${{ needs.path.outputs.java_version }}
+            ${{ needs.setup.outputs.java_version }}
       - name: Upload to Modrinth
         if: ${{ vars.MODREPO == 'modrinth' || vars.MODREPO == 'both' }}
         uses: Kir-Antipov/mc-publish@v3.2
@@ -104,16 +103,16 @@ jobs:
           modrinth-id: KFQYC1Uy
           modrinth-token: ${{ secrets.curseforge_api }}
 
-          files-primary: ${{ needs.path.outputs.file_path }}
+          files-primary: ${{ needs.setup.outputs.file_path }}
 
-          name: ${{ needs.path.outputs.mod_name }}-${{ needs.path.outputs.mod_version }}
-          version: ${{ needs.path.outputs.mod_version }}
+          name: ${{ needs.setup.outputs.mod_name }}-${{ needs.setup.outputs.mod_version }}
+          version: ${{ needs.setup.outputs.mod_version }}
           changelog-file: CHANGELOG.md
 
           loaders: |
             forge
           game-versions: |
-            ${{ needs.path.outputs.mc_minor_version }}
-            ${{ needs.path.outputs.mc_patch_version }}
+            ${{ needs.setup.outputs.mc_minor_version }}
+            ${{ needs.setup.outputs.mc_patch_version }}
           java: |
-            ${{ needs.path.outputs.java_version }}
+            ${{ needs.setup.outputs.java_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [1.16.5-3.69.0] - 2023-03-04
+### Minor Changes
+- Updated: Smelting and Cooking configurations now award XP based on the output item, not the input item.
+### Bugfixes / Tweaks
+- Updated: Configurations to prioritize an explicit item configuration over a tag configuration for which that item is a member
+- Fixed: Bows giving combat xp under certain conditions
+
+## [1.16.5-3.68.0] - 2023-02-12
+### Bugfixes
+- Fixed: DT compat to use the most recent DT build and restored original xp functionality
+- Fixed: Alchemy not giving XP
+- Fixed: Smelting not giving XP
+- Fixed: req and XP bugs with spartan weaponry


### PR DESCRIPTION
To use this on other branches just update the branches at lines 4 and 8 and make sure the changelog reflects the correct version.

In order to use this you will need to add in the Repo settings:
Security > Secrets and Variables > Actions

Secret Variable (as required by MODREPO selection):
CURSEFORGE_API = {curseforge api token}
MODRINTH_API = {modrinth api token}

Normal Variables:
MODREPO = {curseforge|modrinth|both}