### PR TITLE
Add Gravel Data

### DIFF
--- a/src/main/resources/data/minecraft/pmmo/blocks/gravel.json
+++ b/src/main/resources/data/minecraft/pmmo/blocks/gravel.json
@@ -1,0 +1,19 @@
+{
+    "xp_values":{
+        "BLOCK_BREAK":{
+            "excavation":150
+        },
+        "BLOCK_PLACE":{
+            "building": 10
+        }
+    },
+    "requirements":{
+        "PLACE":{
+            "PLACE": {"building":0},
+            "BREAK": {"excavation":0}
+        }
+    },
+    "vein_data":{
+        "consumeAmount": 1
+    }
+}


### PR DESCRIPTION
Adds `minecraft:gravel` block config with same stats as `minecraft:sand`.