### PR TITLE
Adds fishing and swimming bonus heart of the sea

### DIFF
--- a/src/main/resources/data/minecraft/pmmo/items/heart_of_the_sea.json
+++ b/src/main/resources/data/minecraft/pmmo/items/heart_of_the_sea.json
@@ -1,0 +1,14 @@
+{
+    "bonuses": {
+        "WORN": {},
+        "HELD": {
+            "swimming": 1.25,
+            "fishing": 1.10
+        }
+    },
+    "xp_values":{
+        "CRAFT": {
+            "crafting": 0
+        }
+    }
+}


### PR DESCRIPTION
Adds `fishing` 10% and `swimming` 25% bonus to `minecraft:heart_of_the_sea`

Also sets `crafting` xp to 0, since it cannot be crafted.