### PR TITLE
[1.18.2] Fixing Bonuses

### DIFF
--- a/src/main/resources/data/minecraft/pmmo/items/enchanted_golden_apple.json
+++ b/src/main/resources/data/minecraft/pmmo/items/enchanted_golden_apple.json
@@ -12,6 +12,8 @@
         }
     },
     "bonuses": {
-        "magic": 1.5
+        "HELD": {
+            "magic": 1.5
+        }
     }
 }

--- a/src/main/resources/data/minecraft/pmmo/items/golden_apple.json
+++ b/src/main/resources/data/minecraft/pmmo/items/golden_apple.json
@@ -12,6 +12,8 @@
         }
     },
     "bonuses": {
-        "magic": 1.5
+        "HELD": {
+            "magic": 1.5
+        }
     }
 }

--- a/src/main/resources/data/minecraft/pmmo/items/golden_boots.json
+++ b/src/main/resources/data/minecraft/pmmo/items/golden_boots.json
@@ -17,7 +17,9 @@
         }
     },
     "bonuses": {
-        "mining": 1.25
+        "WORN": {
+            "mining": 1.25
+        }
     },
     "negative_effect":{
         "minecraft:slowness":1,

--- a/src/main/resources/data/minecraft/pmmo/items/golden_carrot.json
+++ b/src/main/resources/data/minecraft/pmmo/items/golden_carrot.json
@@ -12,6 +12,8 @@
         }
     },
     "bonuses": {
-        "magic": 1.5
+        "HELD": {
+            "magic": 1.5
+        }
     }
 }

--- a/src/main/resources/data/minecraft/pmmo/items/golden_chestplate.json
+++ b/src/main/resources/data/minecraft/pmmo/items/golden_chestplate.json
@@ -17,7 +17,9 @@
         }
     },
     "bonuses": {
-        "mining": 1.25
+        "WORN": {
+            "mining": 1.25
+        }
     },
     "negative_effect":{
         "minecraft:slowness":1,

--- a/src/main/resources/data/minecraft/pmmo/items/golden_helmet.json
+++ b/src/main/resources/data/minecraft/pmmo/items/golden_helmet.json
@@ -17,7 +17,9 @@
         }
     },
     "bonuses": {
-        "mining": 1.25
+        "WORN": {
+            "mining": 1.25
+        }
     },
     "negative_effect":{
         "minecraft:slowness":1,

--- a/src/main/resources/data/minecraft/pmmo/items/golden_leggings.json
+++ b/src/main/resources/data/minecraft/pmmo/items/golden_leggings.json
@@ -17,7 +17,9 @@
         }
     },
     "bonuses": {
-        "mining": 1.25
+        "WORN": {
+            "mining": 1.25
+        }
     },
     "negative_effect":{
         "minecraft:slowness":1,


### PR DESCRIPTION
For some reason these items didn't have the bonuses containing their condition (`HELD` or `WORN`).