### PR TITLE
Inventory stats fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,21 @@
 buildscript {
     repositories {
         maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
-        maven { url = 'https://maven.parchmentmc.org' }
         mavenCentral()
     }
     dependencies {
         classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
-        classpath 'org.parchmentmc:librarian:1.+'
     }
 }
+
 plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
     id 'net.minecraftforge.gradle' version '[6.0,6.2)'
+    id 'org.parchmentmc.librarian.forgegradle' version '1.+'
 }
-apply plugin: 'org.parchmentmc.librarian.forgegradle'
+
 apply plugin: 'org.spongepowered.mixin'
 
 mixin {
@@ -50,13 +50,13 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
-	copyIdeResources = true
-    mappings channel: 'parchment', version: "1.20.1-2023.07.02-${minecraft_version}"
+    mappings channel: 'parchment', version: "2023.07.23-${minecraft_version}"
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+    copyIdeResources = true
 
     runs {
-        client {
-            workingDirectory project.file('run/client')
+        configureEach {
+            jvmArg "-Dterminal.ansi=true"
             property 'forge.logging.markers', 'REGISTRIES'
             property 'forge.logging.console.level', 'debug'
             mods {
@@ -64,29 +64,19 @@ minecraft {
                     source sourceSets.main
                 }
             }
+        }
+
+        client {
+            workingDirectory project.file('run/client')
         }
 
         server {
             workingDirectory project.file('run/server')
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
-            mods {
-                "${mod_id}" {
-                    source sourceSets.main
-                }
-            }
         }
 
         data {
             workingDirectory project.file('run/client')
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
             args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-            mods {
-                "${mod_id}" {
-                    source sourceSets.main
-                }
-            }
         }
     }
 }
@@ -125,17 +115,14 @@ dependencies {
 
 def resourceTargets = ['META-INF/mods.toml', 'pack.mcmeta']
 def replaceProperties = [
-        minecraft_version: minecraft_version, 
-		minecraft_version_range: minecraft_version_range,
-        forge_version: forge_version, 
-        forge_version_range: forge_version_range,
-        loader_version_range: loader_version_range,
-        mod_id: mod_id, 
-		mod_name: mod_name, 
-//        mod_license: mod_license, 
-        mod_version: mod_version
-//        mod_authors: mod_authors, 
-//        mod_description: mod_description
+    minecraft_version      : minecraft_version,
+    minecraft_version_range: minecraft_version_range,
+    forge_version          : forge_version,
+    forge_version_range    : forge_version_range,
+    loader_version_range   : loader_version_range,
+    mod_id                 : mod_id,
+    mod_name               : mod_name,
+    mod_version            : mod_version
 ]
 processResources {
     inputs.properties replaceProperties

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ pluginManagement {
             name = 'MinecraftForge'
             url = 'https://maven.minecraftforge.net/'
         }
+        maven { url = 'https://maven.parchmentmc.org' }
     }
 }
 

--- a/src/main/java/harmonised/pmmo/client/gui/PlayerStatsScreen.java
+++ b/src/main/java/harmonised/pmmo/client/gui/PlayerStatsScreen.java
@@ -21,7 +21,6 @@ public class PlayerStatsScreen extends EffectRenderingInventoryScreen<InventoryM
     
     public PlayerStatsScreen(Player player) {
         super(player.inventoryMenu, player.getInventory(), Component.translatable("container.crafting"));
-        //this.passEvents = true;
         this.titleLabelX = 97;
     }
     
@@ -58,9 +57,10 @@ public class PlayerStatsScreen extends EffectRenderingInventoryScreen<InventoryM
         this.yMouse = (float)pMouseY;
     }
     
-//    protected void renderLabels(PoseStack pPoseStack, int pX, int pY) {
-//        this.font.draw(pPoseStack, this.title, (float)this.titleLabelX, (float)this.titleLabelY, 4210752);
-//    }
+    @Override
+    protected void renderLabels(GuiGraphics pGuiGraphics, int pMouseX, int pMouseY) {
+        pGuiGraphics.drawString(this.font, this.title, this.titleLabelX, this.titleLabelY, 4210752, false);
+    }
     
     @Override
     protected void renderBg(GuiGraphics graphics, float p_97788_, int p_97789_, int p_97790_) {


### PR DESCRIPTION
This brings an update to latest parchment, some minor gradle cleanup and a couple fixes to the inventory stats screen
 
- Fix stats moving downwards when scrolling and there wasn't enough stats to scroll
- Fix port bug where stats background and icon where being tinted by the color from the stat above
- Fix "Inventory" text being rendered when it shouldn't