### PR TITLE
Add Archery Skill to Leather Armor

### DIFF
--- a/src/main/resources/data/minecraft/pmmo/items/leather_boots.json
+++ b/src/main/resources/data/minecraft/pmmo/items/leather_boots.json
@@ -29,7 +29,7 @@
 			 	 	{"operator":"EQUALS","comparators":["8439583"],"value":{"agility":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["6192150"],"value":{"farming":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["3949738"],"value":{"fishing":1.1}},
-			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1}},
+			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1, "archery":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["11546150"],"value":{"endurance":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16383998"],"value":{"smithing":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16351261"],"value":{"crafting":1.1}},

--- a/src/main/resources/data/minecraft/pmmo/items/leather_chestplate.json
+++ b/src/main/resources/data/minecraft/pmmo/items/leather_chestplate.json
@@ -29,7 +29,7 @@
 			 	 	{"operator":"EQUALS","comparators":["8439583"],"value":{"agility":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["6192150"],"value":{"farming":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["3949738"],"value":{"fishing":1.1}},
-			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1}},
+			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1, "archery":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["11546150"],"value":{"endurance":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16383998"],"value":{"smithing":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16351261"],"value":{"crafting":1.1}},

--- a/src/main/resources/data/minecraft/pmmo/items/leather_helmet.json
+++ b/src/main/resources/data/minecraft/pmmo/items/leather_helmet.json
@@ -29,7 +29,7 @@
 			 	 	{"operator":"EQUALS","comparators":["8439583"],"value":{"agility":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["6192150"],"value":{"farming":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["3949738"],"value":{"fishing":1.1}},
-			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1}},
+			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1, "archery":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["11546150"],"value":{"endurance":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16383998"],"value":{"smithing":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16351261"],"value":{"crafting":1.1}},

--- a/src/main/resources/data/minecraft/pmmo/items/leather_leggings.json
+++ b/src/main/resources/data/minecraft/pmmo/items/leather_leggings.json
@@ -29,7 +29,7 @@
 			 	 	{"operator":"EQUALS","comparators":["8439583"],"value":{"agility":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["6192150"],"value":{"farming":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["3949738"],"value":{"fishing":1.1}},
-			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1}},
+			 	 	{"operator":"EQUALS","comparators":["1908001"],"value":{"combat":1.1, "archery":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["11546150"],"value":{"endurance":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16383998"],"value":{"smithing":1.1}},
 			 	 	{"operator":"EQUALS","comparators":["16351261"],"value":{"crafting":1.1}},


### PR DESCRIPTION
Adds the archery skill to black leather armor (doubles up with combat).

There was no archery skill bonus, and thought this an appropriate place for it.