### PR TITLE
Fix: Consume Events Autovalue Calculation

### DIFF
--- a/src/main/java/harmonised/pmmo/features/autovalues/AutoItem.java
+++ b/src/main/java/harmonised/pmmo/features/autovalues/AutoItem.java
@@ -173,7 +173,8 @@ public class AutoItem {
 					@SuppressWarnings("deprecation")
 					FoodProperties properties = stack.getItem().getFoodProperties();
 					Float nutritionScale = (float)properties.getNutrition() * properties.getSaturationModifier();
-					outMap.put(skill, xp * nutritionScale.longValue());
+					Float xpAward = nutritionScale * (float) xp;
+					outMap.put(skill, xpAward.longValue());
 				});
 			}
 		}


### PR DESCRIPTION
The way this calculation takes place the nutritionScale is converted to a long before it is multiplied by the xp value from the config. A lot of food items in the game have a nutrition scale below 1.0 and when converted to a long become 0 and cannot give xp no matter how high the config value is set.

I tested this using sweet berries, glow berries, and an uncooked potato to make sure they gave xp after the change. Before these would give nothing.