### PR TITLE
Adding A Duration Limit To Swimming Night Vision

### DIFF
--- a/src/main/java/harmonised/pmmo/config/PerksConfig.java
+++ b/src/main/java/harmonised/pmmo/config/PerksConfig.java
@@ -120,7 +120,7 @@ public class PerksConfig {
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:breath").withString(APIUtils.SKILLNAME, "swimming").build());
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:effect").withString(APIUtils.SKILLNAME, "swimming")
 				.withString("effect", "minecraft:night_vision")
-				.withInt(APIUtils.MAX_BOOST, 100)
+				.withInt(APIUtils.MAX_BOOST, 160)
 				.withInt(APIUtils.MIN_LEVEL, 25).build());
 		defaultSettings.put(EventType.SUBMERGED, new ArrayList<>(bodyList));
 		bodyList.clear();

--- a/src/main/java/harmonised/pmmo/config/PerksConfig.java
+++ b/src/main/java/harmonised/pmmo/config/PerksConfig.java
@@ -120,6 +120,7 @@ public class PerksConfig {
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:breath").withString(APIUtils.SKILLNAME, "swimming").build());
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:effect").withString(APIUtils.SKILLNAME, "swimming")
 				.withString("effect", "minecraft:night_vision")
+				.withInt(APIUtils.MAX_BOOST, 100)
 				.withInt(APIUtils.MIN_LEVEL, 25).build());
 		defaultSettings.put(EventType.SUBMERGED, new ArrayList<>(bodyList));
 		bodyList.clear();


### PR DESCRIPTION
Seemed like a sane thing. Limiting night vision duration to 5 seconds.

Note: I don't have a build environment. Please double check this before accepting.