### PR TITLE
[1.21] Update Minecraft wiki links

### DIFF
--- a/wiki/core/perks.md
+++ b/wiki/core/perks.md
@@ -107,7 +107,7 @@ Shoots a firework into the air above the player.  Only works with the `SKILL_UP`
 | `skill`  | `"none"` | The skill this firework should activate for. |
 
 ### <u>pmmo:attribute</u>
-Gives the player an attribute modifier.  This works with modded attributes.  For the full list of vanilla attribute IDs, go [HERE](https://minecraft.fandom.com/wiki/Attribute#Attributes_available_on_all_living_entities)
+Gives the player an attribute modifier.  This works with modded attributes.  For the full list of vanilla attribute IDs, go [HERE](https://minecraft.wiki/w/Attribute#Attributes)
 
 | property         | default | description                                                                          |
 |:-----------------|:-------:|:-------------------------------------------------------------------------------------|

--- a/wiki/core/skills.md
+++ b/wiki/core/skills.md
@@ -24,7 +24,7 @@ There are nine settings you can configure for each skill:
 9. [iconSize](#icon-and-iconsize)
 
 ### Formatted Name
-If you don't want your skill to display as "pmmo.skillname", you need to add a language entry to a resource pack and use that resource pack on your server or personal game.  Your language entry just needs to look like `"pmmo.myskillname":"My Skill Name Beautified"`.  If you are unfamiliar with creating resource packs, you can read more about them [HERE](https://minecraft.fandom.com/wiki/Resource_Pack)
+If you don't want your skill to display as "pmmo.skillname", you need to add a language entry to a resource pack and use that resource pack on your server or personal game.  Your language entry just needs to look like `"pmmo.myskillname":"My Skill Name Beautified"`.  If you are unfamiliar with creating resource packs, you can read more about them [HERE](https://minecraft.wiki/w/Resource_pack)
 
 ### Color and AFK Penalty
 By default, skills display in white.  If that is okay with you, then you don't need to do anything here.  If you do want a custom color though, You will need to add your custom skill to the `pmmo-Skills.toml` file.  This is a server config.  You will find it in your Minecraft folder under `/saves/<save name>/serverconfig/`.  You will then add an entry for your new skill that should look like:

--- a/wiki/features/treasure.md
+++ b/wiki/features/treasure.md
@@ -2,7 +2,7 @@
 
 PMMO 2.0 adds a very simple solution to the previous systems of Treasure, Extra Drops, Rare Mob Drops, and Rare Fish Pool. Using Forge's "Global Loot Modifier" functionality, pmmo adds an on-chance means of adding an extra drop to any loot drop.
 
-In your datapack, under any namespace, add a folder called loot_modifiers. Within this folder add json files with any name you like (must still conform to [datapack naming rules](https://minecraft.fandom.com/wiki/Resource_location#Legal_characters))
+In your datapack, under any namespace, add a folder called loot_modifiers. Within this folder add json files with any name you like (must still conform to [datapack naming rules](https://minecraft.wiki/w/Resource_location#Legal_characters))
 
 Your file will then have these required components
 
@@ -22,7 +22,7 @@ Your file will then have these required components
 In this example, we have a 25% chance of getting a single apple when loot is dropped. Since we do not have any conditions, this will apply to all loot tables including chests.  If `per_level` were set to true this would instead give us 25% chance per level in farming.  This would mean at level 4 farming you would get a 100% chance of apples.
 ### Conditions
 
-Adding conditions specifies when this treasure is to be attempted. Minecraft provides many conditions (called "Predicates") that are used for existing loot tables, and you can use those in this section as well. You can read about thos on [The Minecraft Wiki](https://minecraft.fandom.com/wiki/Predicate). PMMO also adds 4 conditions as well such as player level requirements, and specific block targets. You can read about those [HERE](https://github.com/Caltinor/Project-MMO-2.0/wiki/Loot-Predicates)
+Adding conditions specifies when this treasure is to be attempted. Minecraft provides many conditions (called "Predicates") that are used for existing loot tables, and you can use those in this section as well. You can read about those on [The Minecraft Wiki](https://minecraft.wiki/w/Predicate). PMMO also adds 4 conditions as well such as player level requirements, and specific block targets. You can read about those [HERE](https://github.com/Caltinor/Project-MMO-2.0/wiki/Loot-Predicates)
 
 Conditions work on an "AND" basis unless you use the "alternate" type. Which means that if you put a player skill and a specific block condition, the player must have the requisite skill AND be breaking the specified block to trigger the treasure chance.
 

--- a/wiki/features/triggers.md
+++ b/wiki/features/triggers.md
@@ -51,7 +51,7 @@ This criteria attached to an advancement would trigger when the player reaches l
     }
 ```
 
-This criteria requires the player to be level 3 in agility and swimming in order to trigger. For more information on creating advancements refer to the [minecraft wiki](https://minecraft.fandom.com/wiki/Advancement/JSON_format). There is also [this](https://misode.github.io/advancement/) tool that will do a lot of the setup for you for all your datapack needs, advancements included.
+This criteria requires the player to be level 3 in agility and swimming in order to trigger. For more information on creating advancements refer to [The Minecraft Wiki](https://minecraft.wiki/w/Advancement_definition). There is also [this](https://misode.github.io/advancement/) tool that will do a lot of the setup for you for all your datapack needs, advancements included.
 
 # What this can do.
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.

If this gets merged, should I create pr's for the older wikis too?