### PR TITLE
[1.20.1] Fixing a misspelling `gunslinger` to `gunslinging`

### DIFF
--- a/src/main/java/harmonised/pmmo/config/Config.java
+++ b/src/main/java/harmonised/pmmo/config/Config.java
@@ -416,7 +416,7 @@ public class Config {
 							"minecraft:player_attack", Map.of("combat", 1l),
 							"#minecraft:is_projectile", Map.of("archery", 1l),
 							"#pmmo:magic", Map.of("magic", 15l),
-							"#pmmo:gun", Map.of("gunslinger", 1l)));
+							"#pmmo:gun", Map.of("gunslinging", 1l)));
 			RECEIVE_DAMAGE_XP = TomlConfigHelper.defineObject(builder,
 					"RECEIVE_DAMAGE", CodecTypes.DAMAGE_XP_CODEC, Map.of(
 							"minecraft:generic_kill", Map.of("endurance", 1l),


### PR DESCRIPTION
Fixing `gunslinger` to `gunslinging`