### PR TITLE
[1.20.1] Adding data for Iron's Spellbooks armor

### DIFF
--- a/src/main/resources/data/irons_spellbooks/pmmo/items/archevoker_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/archevoker_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:archevoker_boots", "irons_spellbooks:archevoker_leggings", "irons_spellbooks:archevoker_helmet", "irons_spellbooks:archevoker_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/cryomancer_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/cryomancer_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:cryomancer_boots", "irons_spellbooks:cryomancer_leggings", "irons_spellbooks:cryomancer_helmet", "irons_spellbooks:cryomancer_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/cultist_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/cultist_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:cultist_boots", "irons_spellbooks:cultist_leggings", "irons_spellbooks:cultist_helmet", "irons_spellbooks:cultist_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/electromancer_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/electromancer_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:electromancer_boots", "irons_spellbooks:electromancer_leggings", "irons_spellbooks:electromancer_helmet", "irons_spellbooks:electromancer_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/netherite_mage_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/netherite_mage_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:netherite_mage_boots", "irons_spellbooks:netherite_mage_leggings", "irons_spellbooks:netherite_mage_helmet", "irons_spellbooks:netherite_mage_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 80,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/plagued_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/plagued_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:plagued_boots", "irons_spellbooks:plagued_leggings", "irons_spellbooks:plagued_helmet", "irons_spellbooks:plagued_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/priest_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/priest_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:priest_boots", "irons_spellbooks:priest_leggings", "irons_spellbooks:priest_helmet", "irons_spellbooks:priest_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/pumpkin_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/pumpkin_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.25
+    }
+  },
+  "isTagFor": ["irons_spellbooks:pumpkin_boots", "irons_spellbooks:pumpkin_leggings", "irons_spellbooks:pumpkin_helmet", "irons_spellbooks:pumpkin_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 10
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/pyromancer_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/pyromancer_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:pyromancer_boots", "irons_spellbooks:pyromancer_leggings", "irons_spellbooks:pyromancer_helmet", "irons_spellbooks:pyromancer_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/shadowwalker_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/shadowwalker_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.5
+    }
+  },
+  "isTagFor": ["irons_spellbooks:shadowwalker_boots", "irons_spellbooks:shadowwalker_leggings", "irons_spellbooks:shadowwalker_helmet", "irons_spellbooks:shadowwalker_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 60,
+      "magic": 60
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/tarnished_helmet.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/tarnished_helmet.json
@@ -1,0 +1,12 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.1
+    }
+  },
+  "requirements": {
+    "WEAR": {
+      "magic": 10
+    }
+  }
+}

--- a/src/main/resources/data/irons_spellbooks/pmmo/items/wandering_magician_armor.json
+++ b/src/main/resources/data/irons_spellbooks/pmmo/items/wandering_magician_armor.json
@@ -1,0 +1,14 @@
+{
+  "bonuses": {
+    "WORN": {
+      "magic": 1.1
+    }
+  },
+  "isTagFor": ["irons_spellbooks:wandering_magician_boots", "irons_spellbooks:wandering_magician_leggings", "irons_spellbooks:wandering_magician_helmet", "irons_spellbooks:wandering_magician_chestplate"],
+  "requirements": {
+    "WEAR": {
+      "endurance": 30,
+      "magic": 5
+    }
+  }
+}


### PR DESCRIPTION
Adding armor requirements and bonuses for Iron's Spells and Spellbooks armor.

Data are in line with Minecraft default armor values, with a scaling amount of magic requirement added depending on utility of the armor.