### PR TITLE
Adds the command to rebuild attributes from perks

### DIFF
--- a/src/main/java/harmonised/pmmo/commands/CmdNodeAdmin.java
+++ b/src/main/java/harmonised/pmmo/commands/CmdNodeAdmin.java
@@ -10,11 +10,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import harmonised.pmmo.api.enums.EventType;
 import harmonised.pmmo.api.enums.ObjectType;
 import harmonised.pmmo.config.Config;
 import harmonised.pmmo.config.codecs.PlayerData;
 import harmonised.pmmo.core.Core;
 import harmonised.pmmo.core.IDataStorage;
+import harmonised.pmmo.features.fireworks.FireworkHandler;
 import harmonised.pmmo.network.Networking;
 import harmonised.pmmo.network.clientpackets.CP_SyncData;
 import harmonised.pmmo.network.clientpackets.CP_SyncData_ClearXp;
@@ -22,10 +24,12 @@ import harmonised.pmmo.network.clientpackets.CP_UpdateExperience;
 import harmonised.pmmo.setup.datagen.LangProvider;
 import harmonised.pmmo.storage.Experience;
 import harmonised.pmmo.util.Reference;
+import harmonised.pmmo.util.TagBuilder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -71,6 +75,8 @@ public class CmdNodeAdmin {
 								.executes(CmdNodeAdmin::adminClear)
 								.then(Commands.argument(SKILL_ARG, StringArgumentType.word())
 										.executes(CmdNodeAdmin::adminClearSkill)))
+						.then(Commands.literal("rebuildAttributes")
+								.executes(CmdNodeAdmin::rebuildAttributes))
 						.then(Commands.literal("ignoreReqs")
 								.executes(CmdNodeAdmin::exemptAdmin))
 						.then(Commands.literal("adminBonus")
@@ -129,6 +135,13 @@ public class CmdNodeAdmin {
 		for (ServerPlayer player : EntityArgument.getPlayers(ctx, TARGET_ARG)) {
 			data.getXpMap(player.getUUID()).remove(specifiedSkill);
 			Networking.sendToClient(new CP_SyncData_ClearXp(specifiedSkill), player);
+		}
+		return 0;
+	}
+
+	public static int rebuildAttributes(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+		for (ServerPlayer player : EntityArgument.getPlayers(ctx, TARGET_ARG)) {
+			Core.get(LogicalSide.SERVER).getPerkRegistry().executePerkFiltered(EventType.SKILL_UP, player, "perk", "pmmo:attribute", new CompoundTag());
 		}
 		return 0;
 	}

--- a/wiki/docs/core/commands.mdx
+++ b/wiki/docs/core/commands.mdx
@@ -34,6 +34,7 @@ Note: the first argument after `admin` is a target. The following table is the l
 |`clear`| Resets the target(s) levels and XP.|
 |`ignoreReqs`| Allows the target(s) to ignore any requirements for actions.|
 |`set`| Sets the XP/level in the chosen skill to an exact amount.|
+|`rebuildAttributes`| Rebuilds the target(s) attributes they have gained from `SKILL_UP` perks.|
 
 ## `/pmmo genData`
 genData is a builder-style command.  `begin` resets everything, `create` actually generates the data, and all other commands "build", or set, the settings you want for pmmo to build your datapack.


### PR DESCRIPTION
Adds `/pmmo admin <target(s)> rebuildAttributes` command.

This runs all `SKILL_UP` perks that are of type `pmmo:attribute`. This will assist in [testing configs](https://github.com/Caltinor/Project-MMO-2.0/issues/693) or for server admins to "fix" players who have killed the end dragon and jumped in the pit of "resets all your dang attributes".

