### PR TITLE
Adds Perk Hints to `clear` Command

### DIFF
--- a/src/main/java/harmonised/pmmo/commands/CmdNodeAdmin.java
+++ b/src/main/java/harmonised/pmmo/commands/CmdNodeAdmin.java
@@ -70,6 +70,7 @@ public class CmdNodeAdmin {
 						.then(Commands.literal("clear")
 								.executes(CmdNodeAdmin::adminClear)
 								.then(Commands.argument(SKILL_ARG, StringArgumentType.word())
+										.suggests(SKILL_SUGGESTIONS)
 										.executes(CmdNodeAdmin::adminClearSkill)))
 						.then(Commands.literal("ignoreReqs")
 								.executes(CmdNodeAdmin::exemptAdmin))


### PR DESCRIPTION
Noticed that `/pmmo admin <target(s)> clear <perk>` wasn't giving a hint. Fixes.