### PR TITLE
Update Ars Compat to native

### DIFF
--- a/src/main/java/harmonised/pmmo/config/PerksConfig.java
+++ b/src/main/java/harmonised/pmmo/config/PerksConfig.java
@@ -76,10 +76,12 @@ public record PerksConfig(Map<EventType, List<CompoundTag>> perks) implements Co
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:fireworks").withString(APIUtils.SKILLNAME, "fishing").build());
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:fireworks").withString(APIUtils.SKILLNAME, "crafting").build());
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:fireworks").withString(APIUtils.SKILLNAME, "magic").build());
-		bodyList.add(TagBuilder.start().withString("perk", "ars_scalaes:mana_boost").withString(APIUtils.SKILLNAME, "magic")
-				.withDouble(APIUtils.MAX_BOOST, 3000d).withDouble(APIUtils.PER_LEVEL, 3.0d).build());
-		bodyList.add(TagBuilder.start().withString("perk", "ars_scalaes:mana_regen").withString(APIUtils.SKILLNAME, "magic")
-				.withDouble(APIUtils.MAX_BOOST, 100d).withDouble(APIUtils.PER_LEVEL, 0.06d).build());
+		bodyList.add(TagBuilder.start().withString("perk", "pmmo:attribute").withString(APIUtils.SKILLNAME, "magic")
+				.withDouble(APIUtils.MAX_BOOST, 3000d).withDouble(APIUtils.PER_LEVEL, 3.0d).withString("attribute","ars_nouveau:ars_nouveau.perk.max_mana").build());
+		bodyList.add(TagBuilder.start().withString("perk", "pmmo:attribute").withString(APIUtils.SKILLNAME, "magic")
+				.withDouble(APIUtils.MAX_BOOST, 100d).withDouble(APIUtils.PER_LEVEL, 0.06d).withString("attribute","ars_nouveau:ars_nouveau.perk.mana_regen").build());
+		bodyList.add(TagBuilder.start().withString("perk", "pmmo:attribute").withString(APIUtils.SKILLNAME, "magic")
+				.withDouble(APIUtils.MAX_BOOST, 0d).withDouble(APIUtils.PER_LEVEL, 0.0d).withString("attribute","ars_nouveau:ars_nouveau.perk.spell_damage").build());
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:attribute").withString(APIUtils.SKILLNAME, "magic")
 				.withDouble(APIUtils.MAX_BOOST, 1d).withDouble(APIUtils.PER_LEVEL, 0.005d).withString("attribute", "irons_spellbooks:cooldown_reduction").build());
 		bodyList.add(TagBuilder.start().withString("perk", "pmmo:attribute").withString(APIUtils.SKILLNAME, "magic")

--- a/src/main/java/harmonised/pmmo/setup/datagen/DamageTagProvider.java
+++ b/src/main/java/harmonised/pmmo/setup/datagen/DamageTagProvider.java
@@ -13,7 +13,7 @@ import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 import java.util.concurrent.CompletableFuture;
 
-public class DamageTagProvider extends TagsProvider<DamageType>{
+public class DamageTagProvider extends TagsProvider<DamageType> {
 
     public DamageTagProvider(PackOutput output, CompletableFuture<Provider> lookupProvider, ExistingFileHelper existingFileHelper) {
         super(output, Registries.DAMAGE_TYPE, lookupProvider, Reference.MOD_ID, existingFileHelper);
@@ -62,7 +62,11 @@ public class DamageTagProvider extends TagsProvider<DamageType>{
                 .addOptional(ResourceLocation.parse("ars_nouveau:frost"))
                 .addOptional(ResourceLocation.parse("ars_nouveau:flare"))
                 .addOptional(ResourceLocation.parse("ars_nouveau:crush"))
-                .addOptional(ResourceLocation.parse("ars_nouveau:windshear"));
+                .addOptional(ResourceLocation.parse("ars_nouveau:windshear"))
+                .addOptional(ResourceLocation.parse("ars_elemental:spark"))
+                .addOptional(ResourceLocation.parse("ars_elemental:hellfire"))
+                .addOptional(ResourceLocation.parse("ars_elemental:beheading"))
+                .addOptional(ResourceLocation.parse("ars_elemental:poison"));
         tag(Reference.FROM_GUN)
                 .addOptional(ResourceLocation.parse("cgm:bullet"))
                 .addOptional(ResourceLocation.parse("scguns:bullet"));


### PR DESCRIPTION
Also explicit support magic damage from ars elemental dmg types since the Neoforge magic damage tag is not used