### PR TITLE
Remove refmaps main

### DIFF
--- a/src/main/resources/pmmo.mixins.json
+++ b/src/main/resources/pmmo.mixins.json
@@ -3,7 +3,6 @@
   "minVersion": "0.7",
   "package": "harmonised.pmmo.mixin",
   "compatibilityLevel": "JAVA_21",
-  "refmap": "pmmo.refmap.json",
   "mixins": [
     "AbstractFurnaceTileEntityShrinkMixin",
     "CampfireMixin",


### PR DESCRIPTION
NeoForge don't need refmaps and it only causes warning in the logs.