### PR TITLE
[1.20.1][Wiki] Update scripting.mdx

### DIFF
--- a/wiki/docs/configuration/scripting.mdx
+++ b/wiki/docs/configuration/scripting.mdx
@@ -33,7 +33,7 @@ entity(minecraft:zombie, iceandfire:wyvern, alexmobs:elephant)
 ```
 *Note: when using multiple IDs, each id is separated by a commma*
 
-Target nodes can also take tags and wildcards.  prefixing a `#` to an ID will tell PMMO this id is a tag. eg `blocks(#c:ores/copper)`.  wildcards let you provide a modid and have all objects for that mod configured by the line.  to use wildcards, use an ID like `modid:*`.  eg `entity(alexmobs:*)`
+Target nodes can also take tags and wildcards.  prefixing a `#` to an ID will tell PMMO this id is a tag. eg `block(#forge:ores/copper)`.  wildcards let you provide a modid and have all objects for that mod configured by the line.  to use wildcards, use an ID like `modid:*`.  eg `entity(alexmobs:*)`
 
 PMMO also provides advanced target nodes, which you can read about [here](#advanced-target-nodes)
 


### PR DESCRIPTION
Corrected mistakes with block nodes being called "blocks" and a 1.21 NeoForge tag name being used instead of the 1.20 version.