### PR TITLE
[1.21.1] Adds #pmmo:magic tag entries for Spell Power Attributes mod. 

### DIFF
--- a/src/main/java/harmonised/pmmo/setup/datagen/DamageTagProvider.java
+++ b/src/main/java/harmonised/pmmo/setup/datagen/DamageTagProvider.java
@@ -65,7 +65,13 @@ public class DamageTagProvider extends TagsProvider<DamageType> {
                 .addOptionalElement(ResourceLocation.parse("ars_elemental:spark"))
                 .addOptionalElement(ResourceLocation.parse("ars_elemental:hellfire"))
                 .addOptionalElement(ResourceLocation.parse("ars_elemental:beheading"))
-                .addOptionalElement(ResourceLocation.parse("ars_elemental:poison"));
+                .addOptionalElement(ResourceLocation.parse("ars_elemental:poison"))
+                .addOptionalElement(ResourceLocation.parse("spell_power:fire"))
+                .addOptionalElement(ResourceLocation.parse("spell_power:arcane"))
+                .addOptionalElement(ResourceLocation.parse("spell_power:frost"))
+                .addOptionalElement(ResourceLocation.parse("spell_power:healing"))
+                .addOptionalElement(ResourceLocation.parse("spell_power:lightning"))
+                .addOptionalElement(ResourceLocation.parse("spell_power:soul"));
         getOrCreateRawBuilder(Reference.FROM_GUN)
                 .addOptionalElement(ResourceLocation.parse("cgm:bullet"))
                 .addOptionalElement(ResourceLocation.parse("scguns:bullet"));


### PR DESCRIPTION
Thanks to EnderCode on Discord for the damage types.

Results in a magic.json of:
[magic.json](https://github.com/user-attachments/files/23474880/magic.json)
