### PR TITLE
Fix XpEvent level miscount with static_levels & sprinting XP race on integrated server

### DIFF
--- a/src/main/java/harmonised/pmmo/api/events/XpEvent.java
+++ b/src/main/java/harmonised/pmmo/api/events/XpEvent.java
@@ -25,7 +25,7 @@ public class XpEvent extends PlayerEvent implements ICancellableEvent {
     }
 
     public long endLevel() {
-        Experience newXp = new Experience().merge(ogXp);
+        Experience newXp = new Experience(new Experience.XpLevel(ogXp.getLevel().getLevel()), ogXp.getXp());
         newXp.addXp(amountAwarded);
         return newXp.getLevel().getLevel();
     }

--- a/src/main/java/harmonised/pmmo/events/impl/PlayerTickHandler.java
+++ b/src/main/java/harmonised/pmmo/events/impl/PlayerTickHandler.java
@@ -77,9 +77,14 @@ public class PlayerTickHandler {
 		else if (player.isCrouching())
 			processEvent(EventType.CROUCH, core, event);
 		
-		//update tracker variables
-		healthLast.put(player.getUUID(), player.getHealth());
-		moveLast.put(player.getUUID(), player.position());
+		//update tracker variables. Gate to server-side: these static maps are shared
+		//across sides on an integrated server, and letting the client thread write to
+		//them clobbers the snapshot the server's next 10-tick cycle reads, yielding
+		//magnitude=0 / healthDiff=0 on the next server tick for this player.
+		if (player instanceof ServerPlayer) {
+			healthLast.put(player.getUUID(), player.getHealth());
+			moveLast.put(player.getUUID(), player.position());
+		}
 	}
 	
 	private static void processEvent(EventType type, Core core, PlayerTickEvent event) {
@@ -138,9 +143,9 @@ public class PlayerTickHandler {
 			}
 			
 			CheeseTracker.applyAntiCheese(type, source, event.getEntity(), xpAward);
-			
+
 			List<ServerPlayer> partyMembersInRange = PartyUtils.getPartyMembersInRange((ServerPlayer) event.getEntity());
-			core.awardXP(partyMembersInRange, xpAward);	
+			core.awardXP(partyMembersInRange, xpAward);
 		}
 	}
 

--- a/src/main/java/harmonised/pmmo/storage/Experience.java
+++ b/src/main/java/harmonised/pmmo/storage/Experience.java
@@ -110,6 +110,8 @@ public class Experience {
 
         public XpLevel merge(XpLevel other) {
             level += other.getLevel();
+            xpToNext = getXpForNextLevel(level);
+            xpToGain = level > 0L ? getXpForNextLevel(level - 1L) : 0L;
             return this;
         }
 


### PR DESCRIPTION
**XpEvent level miscount with static_levels**
See Caltinor/Project-MMO-2.0#761.

I created a fork and reproduced the results from the linked issue. I then added these fixes and verified that it now works correctly.

XpEvent.endLevel() double-counted the level when ogXp.xp exceeded the level-0 threshold. new Experience().merge(ogXp) starts at level 0 (xpToNext = staticLevels[0]), then merge calls addXp(ogXp.xp) — which internally increments the level on overflow — before stacking ogXp's stored level on top. With formula leveling the level-0 threshold is tiny so the overflow masks itself; with static_levels like [1000, 2000, 2000, ...] the bug fires at ~50% progress through any level whose threshold exceeds staticLevels[0]. 

XpLevel.merge did not refresh cached thresholds. After level += other.getLevel(), xpToNext / xpToGain still reflected the pre-merge level, leaving the XpLevel inconsistent for any subsequent addXp / setXp call.
Closes Caltinor/Project-MMO-2.0#761


**sprinting XP race on integrated server**

Single player only bug: onPlayerTick has no side filter, so handle() runs on both threads and writes to the static moveLast / healthLast maps. When the client's write landed between two server reads, old equalled the current server position → magnitude = 0 → zero sprinting XP. Intermittent because it depends on whether client/server tickCount align on the same % 10 == 0 boundary, which varies with relogin/dimension-change timing.

I noticed this bug consistently when testing on single player (integrated server). Almost every test session, on every new world, I would just stop getting sprint xp despite having sprint xp set to 1000 acrobatics. 

