### PR TITLE
Fix for NBT requirements with number comparisons crashing the game

### DIFF
--- a/src/main/java/harmonised/pmmo/core/nbt/PathReader.java
+++ b/src/main/java/harmonised/pmmo/core/nbt/PathReader.java
@@ -60,8 +60,12 @@ public class PathReader {
 		}
 		else {
 			Tag value = nbt.get(rawNode(nodeEntry));
-			if (value != null)
-				list.add(value.asString().orElse(""));
+			if (value != null) {
+				value.asNumber().ifPresentOrElse(
+						number -> list.add(number.toString()),
+						() -> list.add(value.asString().orElse(""))
+				);
+			}
 		}
 		
 		return list;


### PR DESCRIPTION
Right now it is not possible to use NBT requirements with numeric comparisons, as `Result` class receives an empty string from item's tag. This is because `asString()` method is only overridden in `StringTag` class, returning nothing for everything else.
I've added a simple check to mitigate that.

[Crash report and an example JSON file](https://gist.github.com/YuRaNnNzZZ/77ec8596bddc933d4618114d9fa08e3c)