### PR TITLE
[1.20.1] Remove genData Commands "withConfig" and "withoutObjects"

### DIFF
--- a/wiki/docs/configuration/config_home.mdx
+++ b/wiki/docs/configuration/config_home.mdx
@@ -24,8 +24,6 @@ To save yourself time, pmmo provides a command to create a datapack for you.  `/
 |:---------------------------------------------|:---------------------------------------------------------------------------------------------------------------|
 | `/pmmo genData begin`                        | resets all settings for a new command sequence                                                                 |
 | `/pmmo genData withOverrides`                | makes all generated files override other datapacks, including the default data                                 |
-| `/pmmo genData withConfigs`                  | includes server configs in generated data                                                                      |
-| `/pmmo genData withoutObjects`               | excludes object config files (items, blocks, entities, etc)                                                    |
 | `/pmmo genData withDefaults`                 | generates all files with their current settings, including any AuotValues                                      |
 | `/pmmo genData simplified`                   | removes all unused properties (for those familiar with pmmo data)                                              |
 | `/pmmo genData modFilter <modid>`            | generates files for only this mod.  may be called multiple times for each mod you want included                |


### PR DESCRIPTION
Remove erroneous config-related `genData` commands from 1.20.1 Wiki config page.